### PR TITLE
feat: Add sender alias to task updates

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -295,11 +295,12 @@ const App: React.FC = () => {
     });
   }, [markdownOffset]);
   
-  const handleAddBulkTaskUpdates = useCallback((taskLineIndexes: number[], updateText: string) => {
+  const handleAddBulkTaskUpdates = useCallback((taskLineIndexes: number[], updateText: string, assigneeAlias: string | null) => {
     setMarkdown(prevMarkdown => {
         const lines = prevMarkdown.split('\n');
         const today = new Date().toISOString().split('T')[0];
-        const newUpdateLine = `  - ${today}: ${updateText}`;
+        const assigneeString = assigneeAlias ? ` (@${assigneeAlias})` : '';
+        const newUpdateLine = `  - ${today}: ${updateText}${assigneeString}`;
         const updateRegex = /^  - \d{4}-\d{2}-\d{2}: .*/;
         
         const sortedIndexes = [...taskLineIndexes].sort((a, b) => b - a);
@@ -453,6 +454,7 @@ const App: React.FC = () => {
             projectTitle={dataForOverview.title}
             viewScope={viewScope}
             totalCost={dataForOverview.totalCost}
+            users={users}
             settings={settings}
             onAddBulkTaskUpdates={handleAddBulkTaskUpdates}
           />
@@ -532,6 +534,7 @@ const App: React.FC = () => {
         onClose={() => setIsSettingsModalOpen(false)}
         settings={settings}
         onSave={saveSettings}
+        users={users}
       />
     </div>
   );

--- a/components/SettingsModal.tsx
+++ b/components/SettingsModal.tsx
@@ -1,24 +1,29 @@
 import React, { useState, useEffect } from 'react';
 import { X, Save } from 'lucide-react';
-import type { Settings } from '../types';
+import type { Settings, User } from '../types';
 
 interface SettingsModalProps {
   isOpen: boolean;
   onClose: () => void;
   settings: Settings;
   onSave: (newSettings: Partial<Settings>) => void;
+  users: User[];
 }
 
-const SettingsModal: React.FC<SettingsModalProps> = ({ isOpen, onClose, settings, onSave }) => {
+const SettingsModal: React.FC<SettingsModalProps> = ({ isOpen, onClose, settings, onSave, users }) => {
   const [currentSettings, setCurrentSettings] = useState(settings);
 
   useEffect(() => {
     setCurrentSettings(settings);
   }, [settings, isOpen]);
 
-  const handleChange = (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement>) => {
     const { name, value } = e.target;
-    setCurrentSettings(prev => ({ ...prev, [name]: value }));
+    if (name === 'senderAlias') {
+      setCurrentSettings(prev => ({ ...prev, senderAlias: value || null }));
+    } else {
+      setCurrentSettings(prev => ({ ...prev, [name]: value }));
+    }
   };
 
   const handleSave = () => {
@@ -40,16 +45,20 @@ const SettingsModal: React.FC<SettingsModalProps> = ({ isOpen, onClose, settings
         
         <div className="space-y-6">
           <div>
-            <label htmlFor="senderName" className="block text-sm font-medium text-slate-300 mb-1">Your Name</label>
-            <p className="text-xs text-slate-500 mb-2">This name is used in the task update note (e.g., "Reminder sent by...").</p>
-            <input
-              id="senderName"
-              name="senderName"
-              type="text"
-              value={currentSettings.senderName}
+            <label htmlFor="senderAlias" className="block text-sm font-medium text-slate-300 mb-1">Reminder Assignee</label>
+            <p className="text-xs text-slate-500 mb-2">Select a user to assign the reminder update note to.</p>
+            <select
+              id="senderAlias"
+              name="senderAlias"
+              value={currentSettings.senderAlias ?? ''}
               onChange={handleChange}
               className="w-full bg-slate-700 border border-slate-600 rounded-md p-2 text-slate-200 focus:ring-2 focus:ring-indigo-500 outline-none"
-            />
+            >
+              <option value="">None (Just a note)</option>
+              {users.map(user => (
+                <option key={user.alias} value={user.alias}>{user.name}</option>
+              ))}
+            </select>
           </div>
 
           <div>

--- a/hooks/useSettings.ts
+++ b/hooks/useSettings.ts
@@ -4,7 +4,7 @@ import type { Settings } from '../types';
 const SETTINGS_KEY = 'md-tasker-email-settings';
 
 const DEFAULT_SETTINGS: Settings = {
-  senderName: 'Project Manager',
+  senderAlias: null,
   emailPreamble: 'Hi {userName},\n\nThis is a friendly reminder about your outstanding tasks for the project. Please see the list below:',
   emailPostamble: 'Please provide an update when you can.\n\nBest regards,',
 };

--- a/types.ts
+++ b/types.ts
@@ -40,7 +40,7 @@ export interface Project {
 }
 
 export interface Settings {
-  senderName: string;
+  senderAlias: string | null;
   emailPreamble: string;
   emailPostamble: string;
 }


### PR DESCRIPTION
Introduces a sender alias setting to allow users to specify a name or identifier for task updates. This replaces the generic "senderName" and allows for more flexible attribution in task notes. The UI has been updated to accommodate this change, including a select input for users and handling null values for the alias.