### PR TITLE
feat: Add section move and duplicate functionality

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -245,6 +245,47 @@ const App: React.FC = () => {
     });
   }, [viewScope, currentProjectIndex, projects]);
 
+  const handleMoveSection = useCallback((sectionToMove: {startLine: number, endLine: number}, destinationLine: number) => {
+    setMarkdown(prev => {
+        const lines = prev.split('\n');
+        
+        const sectionContent = lines.slice(sectionToMove.startLine, sectionToMove.endLine + 1);
+        
+        const linesWithoutSection = [
+            ...lines.slice(0, sectionToMove.startLine),
+            ...lines.slice(sectionToMove.endLine + 1)
+        ];
+
+        const adjustedDestinationLine = destinationLine > sectionToMove.startLine 
+            ? destinationLine - sectionContent.length 
+            : destinationLine;
+
+        const newLines = [
+            ...linesWithoutSection.slice(0, adjustedDestinationLine),
+            ...sectionContent,
+            ...linesWithoutSection.slice(adjustedDestinationLine)
+        ];
+
+        return newLines.join('\n');
+    });
+  }, []);
+
+  const handleDuplicateSection = useCallback((sectionToDuplicate: {startLine: number, endLine: number}, destinationLine: number) => {
+    setMarkdown(prev => {
+        const lines = prev.split('\n');
+        
+        const sectionContent = lines.slice(sectionToDuplicate.startLine, sectionToDuplicate.endLine + 1);
+        
+        const newLines = [
+            ...lines.slice(0, destinationLine),
+            ...sectionContent,
+            ...lines.slice(destinationLine)
+        ];
+
+        return newLines.join('\n');
+    });
+  }, []);
+
   const handleToggleFullEdit = useCallback(() => {
     setFullEditContent(displayMarkdown);
     setIsFullEditMode(true);
@@ -429,6 +470,8 @@ const App: React.FC = () => {
               onSectionUpdate={handleSectionUpdate}
               onToggle={handleToggle}
               onUpdateTaskBlock={handleUpdateTaskBlock}
+              onMoveSection={handleMoveSection}
+              onDuplicateSection={handleDuplicateSection}
             />
         );
       case 'users':

--- a/components/DuplicateSectionControl.tsx
+++ b/components/DuplicateSectionControl.tsx
@@ -1,0 +1,81 @@
+import React, { useState, useRef, useEffect } from 'react';
+import { Section } from '../hooks/useSectionParser';
+import { Copy } from 'lucide-react';
+
+interface DuplicateSectionControlProps {
+    allSections: Section[];
+    currentSectionIndex: number;
+    onDuplicateSection: (destinationLine: number) => void;
+}
+
+const DuplicateSectionControl: React.FC<DuplicateSectionControlProps> = ({ allSections, currentSectionIndex, onDuplicateSection }) => {
+    const [isOpen, setIsOpen] = useState(false);
+    const dropdownRef = useRef<HTMLDivElement>(null);
+
+    useEffect(() => {
+        const handleClickOutside = (event: MouseEvent) => {
+            if (dropdownRef.current && !dropdownRef.current.contains(event.target as Node)) {
+                setIsOpen(false);
+            }
+        };
+        document.addEventListener('mousedown', handleClickOutside);
+        return () => document.removeEventListener('mousedown', handleClickOutside);
+    }, []);
+
+    const handleDuplicate = (destinationLine: number) => {
+        onDuplicateSection(destinationLine);
+        setIsOpen(false);
+    };
+
+    const currentSection = allSections[currentSectionIndex];
+    if (!currentSection) return null;
+
+    return (
+        <div className="relative" ref={dropdownRef}>
+            <button
+                onClick={() => setIsOpen(p => !p)}
+                className="p-2 rounded-full bg-slate-700/50 text-slate-400 opacity-0 group-hover:opacity-100 focus:opacity-100 transition-opacity duration-200 hover:bg-indigo-600 hover:text-white"
+                aria-haspopup="true"
+                aria-expanded={isOpen}
+                aria-label="Duplicate section"
+                title="Duplicate section"
+            >
+                <Copy className="w-4 h-4" />
+            </button>
+
+            {isOpen && (
+                <div className="absolute right-0 mt-2 w-64 bg-slate-800 border border-slate-700 rounded-lg shadow-xl z-30" role="menu">
+                    <div className="p-1">
+                        <div className="px-2 py-1 text-xs font-semibold text-slate-400">Duplicate section to...</div>
+                        
+                        <button
+                            onClick={() => handleDuplicate(0)}
+                            className="w-full text-left px-3 py-2 text-sm rounded-md text-slate-200 hover:bg-slate-700"
+                            role="menuitem"
+                        >
+                            Top of file
+                        </button>
+                        
+                        {allSections.map((section) => {
+                            const sectionTitle = section.heading?.text || 'Preamble';
+                            
+                            return (
+                                <button
+                                    key={section.startLine}
+                                    onClick={() => handleDuplicate(section.endLine + 1)}
+                                    className="w-full text-left px-3 py-2 text-sm rounded-md text-slate-200 hover:bg-slate-700 truncate"
+                                    role="menuitem"
+                                    title={`After: "${sectionTitle}"`}
+                                >
+                                    After: "{sectionTitle}"
+                                </button>
+                            );
+                        })}
+                    </div>
+                </div>
+            )}
+        </div>
+    );
+};
+
+export default DuplicateSectionControl;

--- a/components/EditableDocumentView.tsx
+++ b/components/EditableDocumentView.tsx
@@ -11,23 +11,29 @@ interface EditableDocumentViewProps {
   onSectionUpdate: (startLine: number, endLine: number, newContent: string) => void;
   onToggle: (lineIndex: number, isCompleted: boolean) => void;
   onUpdateTaskBlock: (absoluteStartLine: number, originalLineCount: number, newContent: string) => void;
+  onMoveSection: (sectionToMove: {startLine: number, endLine: number}, destinationLine: number) => void;
+  onDuplicateSection: (sectionToDuplicate: {startLine: number, endLine: number}, destinationLine: number) => void;
 }
 
 const EditableDocumentView: React.FC<EditableDocumentViewProps> = (props) => {
-  const { markdown, onSectionUpdate, ...handlers } = props;
+  const { markdown, onSectionUpdate, onMoveSection, onDuplicateSection, ...handlers } = props;
   const sections = useSectionParser(markdown);
 
   return (
     <div className="h-full overflow-y-auto">
         <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
             <div className="space-y-4">
-                {sections.map(section => (
+                {sections.map((section, index) => (
                     <EditableSection
-                        key={section.startLine}
+                        key={section.heading?.text ? `${section.heading.text}-${section.startLine}` : section.startLine}
                         section={section}
-                        users={props.users}
+                        sectionIndex={index}
+                        allSections={sections}
                         onSectionUpdate={onSectionUpdate}
+                        onMoveSection={onMoveSection}
+                        onDuplicateSection={onDuplicateSection}
                         {...handlers}
+                        users={props.users}
                     />
                 ))}
             </div>

--- a/components/EditableSection.tsx
+++ b/components/EditableSection.tsx
@@ -7,6 +7,8 @@ import Toolbar from './Toolbar';
 import { Pencil, Save, X, CheckCircle2, CalendarDays, ChevronRight } from 'lucide-react';
 import InputModal from './InputModal';
 import DatePickerModal from './DatePickerModal';
+import MoveSectionControl from './MoveSectionControl';
+import DuplicateSectionControl from './DuplicateSectionControl';
 
 
 // Autocomplete Component for @ mentions
@@ -442,13 +444,17 @@ const InteractiveTaskItem: React.FC<{
 // The Main EditableSection Component
 interface EditableSectionProps {
   section: Section;
+  sectionIndex: number;
+  allSections: Section[];
   users: User[];
   onSectionUpdate: (startLine: number, endLine: number, newContent: string) => void;
+  onMoveSection: (sectionToMove: {startLine: number, endLine: number}, destinationLine: number) => void;
+  onDuplicateSection: (sectionToDuplicate: {startLine: number, endLine: number}, destinationLine: number) => void;
   onToggle: (lineIndex: number, isCompleted: boolean) => void;
   onUpdateTaskBlock: (absoluteStartLine: number, originalLineCount: number, newContent: string) => void;
 }
 
-const EditableSection: React.FC<EditableSectionProps> = ({ section, onSectionUpdate, ...props }) => {
+const EditableSection: React.FC<EditableSectionProps> = ({ section, sectionIndex, allSections, onSectionUpdate, onMoveSection, onDuplicateSection, ...props }) => {
   const [isEditing, setIsEditing] = useState(() => !section.content.trim());
   const [editedContent, setEditedContent] = useState(section.content);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
@@ -505,6 +511,14 @@ const EditableSection: React.FC<EditableSectionProps> = ({ section, onSectionUpd
   const handleCancel = () => {
     setEditedContent(section.content);
     setIsEditing(false);
+  };
+
+  const handleMove = (destinationLine: number) => {
+    onMoveSection({ startLine: section.startLine, endLine: section.endLine }, destinationLine);
+  };
+  
+  const handleDuplicate = (destinationLine: number) => {
+    onDuplicateSection({ startLine: section.startLine, endLine: section.endLine }, destinationLine);
   };
 
   const handleMentionSelect = useCallback((user: User) => {
@@ -890,13 +904,25 @@ const EditableSection: React.FC<EditableSectionProps> = ({ section, onSectionUpd
 
   return (
     <div className="relative group bg-slate-800/30 hover:bg-slate-800/50 rounded-lg transition-colors duration-200">
+       <div className="absolute top-2 right-2 z-10 flex items-center gap-2">
+        <DuplicateSectionControl
+            allSections={allSections}
+            currentSectionIndex={sectionIndex}
+            onDuplicateSection={handleDuplicate}
+        />
+        <MoveSectionControl
+          allSections={allSections}
+          currentSectionIndex={sectionIndex}
+          onMoveSection={handleMove}
+        />
        <button 
         onClick={() => setIsEditing(true)} 
-        className="absolute top-2 right-2 z-10 p-2 rounded-full bg-slate-700/50 text-slate-400 opacity-0 group-hover:opacity-100 focus:opacity-100 transition-opacity duration-200 hover:bg-indigo-600 hover:text-white"
+        className="p-2 rounded-full bg-slate-700/50 text-slate-400 opacity-0 group-hover:opacity-100 focus:opacity-100 transition-opacity duration-200 hover:bg-indigo-600 hover:text-white"
         aria-label="Edit section"
       >
         <Pencil className="w-4 h-4" />
       </button>
+      </div>
       <div className="p-4 prose-invert pb-8">
         {renderPreviewContent()}
       </div>

--- a/components/MoveSectionControl.tsx
+++ b/components/MoveSectionControl.tsx
@@ -1,0 +1,87 @@
+import React, { useState, useRef, useEffect } from 'react';
+import { Section } from '../hooks/useSectionParser';
+import { ChevronsUpDown } from 'lucide-react';
+
+interface MoveSectionControlProps {
+    allSections: Section[];
+    currentSectionIndex: number;
+    onMoveSection: (destinationLine: number) => void;
+}
+
+const MoveSectionControl: React.FC<MoveSectionControlProps> = ({ allSections, currentSectionIndex, onMoveSection }) => {
+    const [isOpen, setIsOpen] = useState(false);
+    const dropdownRef = useRef<HTMLDivElement>(null);
+
+    useEffect(() => {
+        const handleClickOutside = (event: MouseEvent) => {
+            if (dropdownRef.current && !dropdownRef.current.contains(event.target as Node)) {
+                setIsOpen(false);
+            }
+        };
+        document.addEventListener('mousedown', handleClickOutside);
+        return () => document.removeEventListener('mousedown', handleClickOutside);
+    }, []);
+
+    const handleMove = (destinationLine: number) => {
+        onMoveSection(destinationLine);
+        setIsOpen(false);
+    };
+
+    const currentSection = allSections[currentSectionIndex];
+    if (!currentSection) return null;
+
+    return (
+        <div className="relative" ref={dropdownRef}>
+            <button
+                onClick={() => setIsOpen(p => !p)}
+                className="p-2 rounded-full bg-slate-700/50 text-slate-400 opacity-0 group-hover:opacity-100 focus:opacity-100 transition-opacity duration-200 hover:bg-indigo-600 hover:text-white"
+                aria-haspopup="true"
+                aria-expanded={isOpen}
+                aria-label="Move section"
+                title="Move section"
+            >
+                <ChevronsUpDown className="w-4 h-4" />
+            </button>
+
+            {isOpen && (
+                <div className="absolute right-0 mt-2 w-64 bg-slate-800 border border-slate-700 rounded-lg shadow-xl z-30" role="menu">
+                    <div className="p-1">
+                        <div className="px-2 py-1 text-xs font-semibold text-slate-400">Move section to...</div>
+                        
+                        {currentSectionIndex > 0 && (
+                            <button
+                                onClick={() => handleMove(0)}
+                                className="w-full text-left px-3 py-2 text-sm rounded-md text-slate-200 hover:bg-slate-700"
+                                role="menuitem"
+                            >
+                                Top of file
+                            </button>
+                        )}
+                        
+                        {allSections.map((section, index) => {
+                            if (index === currentSectionIndex || index === currentSectionIndex - 1) {
+                                return null;
+                            }
+
+                            const sectionTitle = section.heading?.text || 'Preamble';
+                            
+                            return (
+                                <button
+                                    key={section.startLine}
+                                    onClick={() => handleMove(section.endLine + 1)}
+                                    className="w-full text-left px-3 py-2 text-sm rounded-md text-slate-200 hover:bg-slate-700 truncate"
+                                    role="menuitem"
+                                    title={`After: "${sectionTitle}"`}
+                                >
+                                    After: "{sectionTitle}"
+                                </button>
+                            );
+                        })}
+                    </div>
+                </div>
+            )}
+        </div>
+    );
+};
+
+export default MoveSectionControl;


### PR DESCRIPTION
Implements the ability to move and duplicate entire markdown sections. This enhances the interactive tasker by allowing users to reorganize and copy content blocks within their documents directly from the editor interface.

The changes include:
- New handler functions in `App.tsx` to manage the state updates for moving and duplicating sections.
- Modifications to `EditableDocumentView.tsx` to pass down these new handlers.
- Introduction of `EditableSection.tsx` to incorporate UI controls for triggering these actions.
- Creation of dedicated `MoveSectionControl.tsx` and `DuplicateSectionControl.tsx` components for the UI.