### PR TITLE
feat: Add project scoping and Table of Contents

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -262,15 +262,14 @@ const App: React.FC = () => {
 
         const contentToInsert = [...sectionContent];
 
-        // Add a blank line before if the preceding line isn't already blank.
         if (adjustedDestinationLine > 0 && linesWithoutSection[adjustedDestinationLine - 1]?.trim() !== '') {
             contentToInsert.unshift('');
         }
-
-        // Add a blank line after if the succeeding line isn't already blank.
+        
         if (adjustedDestinationLine < linesWithoutSection.length && linesWithoutSection[adjustedDestinationLine]?.trim() !== '') {
             contentToInsert.push('');
         }
+
 
         const newLines = [
             ...linesWithoutSection.slice(0, adjustedDestinationLine),
@@ -484,6 +483,9 @@ const App: React.FC = () => {
               onUpdateTaskBlock={handleUpdateTaskBlock}
               onMoveSection={handleMoveSection}
               onDuplicateSection={handleDuplicateSection}
+              projects={projects}
+              viewScope={viewScope}
+              currentProjectIndex={currentProjectIndex}
             />
         );
       case 'users':

--- a/components/EditableDocumentView.tsx
+++ b/components/EditableDocumentView.tsx
@@ -1,8 +1,8 @@
 
 
-import React from 'react';
-import { useSectionParser, Section } from '../hooks/useSectionParser';
-import type { User } from '../types';
+import React, { useMemo } from 'react';
+import { useSectionParser } from '../hooks/useSectionParser';
+import type { User, Project, Heading } from '../types';
 import EditableSection from './EditableSection';
 
 interface EditableDocumentViewProps {
@@ -13,29 +13,45 @@ interface EditableDocumentViewProps {
   onUpdateTaskBlock: (absoluteStartLine: number, originalLineCount: number, newContent: string) => void;
   onMoveSection: (sectionToMove: {startLine: number, endLine: number}, destinationLine: number) => void;
   onDuplicateSection: (sectionToDuplicate: {startLine: number, endLine: number}, destinationLine: number) => void;
+  projects: Project[];
+  viewScope: 'single' | 'all';
+  currentProjectIndex: number;
 }
 
 const EditableDocumentView: React.FC<EditableDocumentViewProps> = (props) => {
-  const { markdown, onSectionUpdate, onMoveSection, onDuplicateSection, ...handlers } = props;
+  const { markdown, onSectionUpdate, onMoveSection, onDuplicateSection, projects, viewScope, currentProjectIndex, ...handlers } = props;
   const sections = useSectionParser(markdown);
+
+  const relevantProjects = useMemo(() =>
+    viewScope === 'all' ? projects : (projects[currentProjectIndex] ? [projects[currentProjectIndex]] : []),
+    [viewScope, projects, currentProjectIndex]
+  );
 
   return (
     <div className="h-full overflow-y-auto">
         <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
             <div className="space-y-4">
-                {sections.map((section, index) => (
-                    <EditableSection
-                        key={section.heading?.text ? `${section.heading.text}-${section.startLine}` : section.startLine}
-                        section={section}
-                        sectionIndex={index}
-                        allSections={sections}
-                        onSectionUpdate={onSectionUpdate}
-                        onMoveSection={onMoveSection}
-                        onDuplicateSection={onDuplicateSection}
-                        {...handlers}
-                        users={props.users}
-                    />
-                ))}
+                {sections.map((section, index) => {
+                    const projectForSection = relevantProjects.find(
+                        p => section.startLine >= p.startLine && section.startLine <= p.endLine
+                    );
+                    const tocHeadings = projectForSection?.headings;
+
+                    return (
+                        <EditableSection
+                            key={section.heading?.text ? `${section.heading.text}-${section.startLine}` : section.startLine}
+                            section={section}
+                            sectionIndex={index}
+                            allSections={sections}
+                            onSectionUpdate={onSectionUpdate}
+                            onMoveSection={onMoveSection}
+                            onDuplicateSection={onDuplicateSection}
+                            tocHeadings={tocHeadings}
+                            {...handlers}
+                            users={props.users}
+                        />
+                    );
+                })}
             </div>
         </div>
     </div>

--- a/components/TableOfContents.tsx
+++ b/components/TableOfContents.tsx
@@ -1,0 +1,67 @@
+import React, { useState } from 'react';
+import type { Heading } from '../types';
+import { BookMarked, ChevronRight } from 'lucide-react';
+
+interface TableOfContentsProps {
+  headings: Heading[];
+}
+
+const TableOfContents: React.FC<TableOfContentsProps> = ({ headings }) => {
+  const [isOpen, setIsOpen] = useState(false);
+  
+  const projectHeadings = headings.filter(h => h.level > 1);
+
+  const handleLinkClick = (e: React.MouseEvent<HTMLAnchorElement>, slug: string) => {
+    e.preventDefault();
+    document.getElementById(slug)?.scrollIntoView({
+      behavior: 'smooth',
+      block: 'start'
+    });
+    setIsOpen(false);
+  };
+
+  if (projectHeadings.length === 0) {
+    return null;
+  }
+
+  return (
+    <div className="absolute top-4 -left-4 z-20">
+      <button
+        onClick={() => setIsOpen(p => !p)}
+        className="p-2 rounded-full bg-slate-700 text-slate-300 hover:bg-indigo-600 hover:text-white transition-all duration-300 shadow-lg"
+        title="Table of Contents"
+        aria-label="Toggle Table of Contents"
+        aria-expanded={isOpen}
+      >
+        <BookMarked className={`w-5 h-5 transition-transform duration-300 ${isOpen ? 'rotate-12' : ''}`} />
+      </button>
+
+      <div
+        className={`absolute top-0 left-12 w-64 transition-all duration-300 ease-in-out ${
+          isOpen ? 'opacity-100 translate-x-0' : 'opacity-0 -translate-x-4 pointer-events-none'
+        }`}
+      >
+        <nav className="bg-slate-900/80 backdrop-blur-md border border-slate-700 rounded-lg shadow-2xl p-4">
+          <h4 className="font-bold text-slate-200 mb-2">Contents</h4>
+          <ul className="space-y-1.5 max-h-80 overflow-y-auto">
+            {projectHeadings.map((heading) => (
+              <li key={heading.slug}>
+                <a
+                  href={`#${heading.slug}`}
+                  onClick={(e) => handleLinkClick(e, heading.slug)}
+                  className="flex items-start text-sm text-slate-400 hover:text-indigo-400 transition-colors"
+                  style={{ paddingLeft: `${(heading.level - 2) * 16}px` }}
+                >
+                   <ChevronRight className="w-4 h-3 mr-1 mt-0.5 flex-shrink-0" />
+                   <span className="flex-grow">{heading.text}</span>
+                </a>
+              </li>
+            ))}
+          </ul>
+        </nav>
+      </div>
+    </div>
+  );
+};
+
+export default TableOfContents;

--- a/hooks/useMarkdownParser.ts
+++ b/hooks/useMarkdownParser.ts
@@ -1,4 +1,5 @@
 
+
 import { useMemo } from 'react';
 import { User, Task, GroupedTasks, TaskUpdate, Project, Heading } from '../types';
 
@@ -45,6 +46,8 @@ export const useMarkdownParser = (markdown: string, users: User[]): Project[] =>
             projectBoundaries.push({ title: 'Project Overview', startLine: 0 });
         }
 
+        const existingSlugs = new Set<string>();
+
         projectBoundaries.forEach((boundary, idx) => {
             const startLine = boundary.startLine;
             const endLine = (idx + 1 < projectBoundaries.length) ? projectBoundaries[idx + 1].startLine - 1 : lines.length - 1;
@@ -52,7 +55,6 @@ export const useMarkdownParser = (markdown: string, users: User[]): Project[] =>
             const projectLines = lines.slice(startLine, endLine + 1);
             const currentProjectTasks: Task[] = [];
             const currentProjectHeadings: Heading[] = [];
-            const existingSlugs = new Set<string>();
             
             const taskRegex = /^- \[( |x)\] (.*)/;
             const assigneeRegex = /\s\(@([a-zA-Z0-9_]+)\)/;


### PR DESCRIPTION
Introduces project scoping to the Interactive Markdown Tasker, allowing users to filter tasks by project. This is achieved by parsing markdown for project boundaries.

Additionally, a Table of Contents component has been implemented, which displays section headings for improved navigation within the document.

The changes include:
- Enhancements to `useMarkdownParser` to identify and group tasks by project.
- Updates to `App.tsx` to pass project-related props down to `EditableDocumentView`.
- Introduction of a `TableOfContents` component.
- Modifications to `EditableDocumentView` and `EditableSection` to integrate the new project filtering and ToC features.