### PR TITLE
feat(archive): Implement project archiving and restoration

### DIFF
--- a/components/ProjectActions.tsx
+++ b/components/ProjectActions.tsx
@@ -13,10 +13,11 @@ type ViewScope = 'single' | 'all';
 interface ProjectActionsProps {
     viewScope: ViewScope;
     currentProject: Project;
+    isArchiveView?: boolean;
 }
 
-const ProjectActions: React.FC<ProjectActionsProps> = ({ viewScope, currentProject }) => {
-    const { markdown, projects, users, settings, importProject } = useProject();
+const ProjectActions: React.FC<ProjectActionsProps> = ({ viewScope, currentProject, isArchiveView }) => {
+    const { markdown, archiveMarkdown, projects, users, settings, importProject } = useProject();
     const [isOpen, setIsOpen] = useState(false);
     const [isDailyReportModalOpen, setIsDailyReportModalOpen] = useState(false);
     const dropdownRef = useRef<HTMLDivElement>(null);
@@ -32,12 +33,12 @@ const ProjectActions: React.FC<ProjectActionsProps> = ({ viewScope, currentProje
     }, []);
 
     const handleExportProject = useCallback(() => {
-        const projectData = { users, markdown, settings };
+        const projectData = { users, markdown, archiveMarkdown, settings };
         const blob = new Blob([JSON.stringify(projectData, null, 2)], { type: 'application/json' });
         const filename = projects.length > 1 ? 'Multi-Project.mdtasker' : `${currentProject.title.replace(/\s/g, '_')}.mdtasker`;
         saveAs(blob, filename);
         setIsOpen(false);
-    }, [users, markdown, settings, projects, currentProject.title]);
+    }, [users, markdown, archiveMarkdown, settings, projects, currentProject.title]);
     
     const createInlinesFromMarkdown = (text: string, options: any = {}): (docx.TextRun | docx.ExternalHyperlink)[] => {
         const parts = text.split(/(\*\*.*?\*\*|\*.*?\*|\[.*?\]\(.*?\))/g);

--- a/types.ts
+++ b/types.ts
@@ -72,6 +72,7 @@ export interface BackupRecord {
 
 export interface FullProjectState {
     markdown: string;
+    archiveMarkdown?: string;
     users: User[];
     settings: Omit<Settings, 'supabaseUrl' | 'supabaseAnonKey' | 'supabaseEmail'>;
 }


### PR DESCRIPTION
Introduces the ability to archive and restore projects. This includes:
- Adding `archiveMarkdown` to `FullProjectState` to store archived content.
- Modifying the `App` component to include an 'archive' view.
- Adding 'archive' and 'restore' actions to `ProjectActions` and `EditableSection` respectively.
- Updating `EditableDocumentView` to handle archive views.
- Adding `archiveSection` and `restoreSection` functions to the project context.