### PR TITLE
feat: Add configurable email creation date label

### DIFF
--- a/components/ProjectOverview.tsx
+++ b/components/ProjectOverview.tsx
@@ -156,8 +156,9 @@ const UserTaskCard: React.FC<{
           .map(title => {
               const projectTasks = tasksByProject[title].map(task => {
                 const costString = task.cost ? ` ($${task.cost.toFixed(2)})` : '';
+                const creationDateString = task.creationDate ? ` (${settings.emailCreationDateLabel} ${new Date(task.creationDate + 'T00:00:00').toLocaleDateString()})` : '';
                 const formattedText = formatMarkdownForEmail(task.text);
-                return `- [ ] ${formattedText}${costString}`;
+                return `- [ ] ${formattedText}${costString}${creationDateString}`;
               }).join('\n');
               return projectTitles.length > 1 ? `\nProject: ${title}\n${projectTasks}` : projectTasks;
           })

--- a/components/SettingsModal.tsx
+++ b/components/SettingsModal.tsx
@@ -68,6 +68,11 @@ const SettingsModal: React.FC<SettingsModalProps> = ({ isOpen, onClose }) => {
                         <input type="text" id="reminderMessage" name="reminderMessage" value={currentSettings.reminderMessage} onChange={handleChange} className="w-full bg-slate-700 border border-slate-600 rounded-md p-2 text-slate-200 focus:ring-2 focus:ring-indigo-500 outline-none" />
                     </div>
                     <div>
+                        <label htmlFor="emailCreationDateLabel" className="block text-sm font-medium text-slate-300 mb-1">Email Creation Date Label</label>
+                        <p className="text-xs text-slate-500 mb-2">The label used for the task creation date in emails (e.g., "Created:", "Creato il:").</p>
+                        <input type="text" id="emailCreationDateLabel" name="emailCreationDateLabel" value={currentSettings.emailCreationDateLabel} onChange={handleChange} className="w-full bg-slate-700 border border-slate-600 rounded-md p-2 text-slate-200 focus:ring-2 focus:ring-indigo-500 outline-none" />
+                    </div>
+                    <div>
                         <label htmlFor="emailSubject" className="block text-sm font-medium text-slate-300 mb-1">Email Subject</label>
                         <p className="text-xs text-slate-500 mb-2">Use <code className="bg-slate-900 px-1 rounded">{'{projectTitle}'}</code> as a placeholder.</p>
                         <input type="text" id="emailSubject" name="emailSubject" value={currentSettings.emailSubject} onChange={handleChange} className="w-full bg-slate-700 border border-slate-600 rounded-md p-2 text-slate-200 focus:ring-2 focus:ring-indigo-500 outline-none" />

--- a/hooks/useSettings.ts
+++ b/hooks/useSettings.ts
@@ -10,6 +10,7 @@ const DEFAULT_SETTINGS: Settings = {
   emailPostamble: 'Please provide an update when you can.\n\nBest regards,',
   emailSignature: '{senderName}',
   reminderMessage: 'Reminder sent.',
+  emailCreationDateLabel: 'Created:',
   ccAlias: null,
   supabaseUrl: null,
   supabaseAnonKey: null,

--- a/types.ts
+++ b/types.ts
@@ -58,6 +58,7 @@ export interface Settings {
   emailPostamble: string;
   emailSignature: string;
   reminderMessage: string;
+  emailCreationDateLabel: string;
   ccAlias?: string | null;
   supabaseUrl?: string | null;
   supabaseAnonKey?: string | null;


### PR DESCRIPTION
Introduces a new setting to customize the label used for the task creation date when tasks are formatted for emails. This allows users to specify a more appropriate label for different languages or preferences. The label is now displayed in the task list within emails.