### PR TITLE
feat: Integrate remark for advanced markdown parsing

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -1,5 +1,9 @@
 
 
+
+
+
+
 import React, { useState, useCallback, useRef, useEffect, useMemo } from 'react';
 import UserManagement from './components/UserManagement';
 import ProjectOverview from './components/ProjectOverview';
@@ -266,7 +270,6 @@ const App: React.FC = () => {
     const source = viewScope === 'all' ? aggregatedData : currentProject;
     if (!hideCompletedTasks) return source;
 
-    // FIX: Add explicit type to lambda parameter to fix 'group' property being inferred as 'unknown'.
     const filteredGroupedTasks = Object.entries(source.groupedTasks).reduce((acc, [alias, group]: [string, { user: User; tasks: Task[] }]) => {
         acc[alias] = {
             ...group,
@@ -509,10 +512,13 @@ const App: React.FC = () => {
           <TimelineView
             tasks={tasksForTimeline}
             viewScope={viewScope}
+            onNavigate={handleNavigateToSection}
           />
         );
     }
   }
+
+  const isArchive = view === 'archive';
 
   return (
     <div className="h-screen bg-slate-900 text-white font-sans flex flex-col overflow-hidden">
@@ -570,7 +576,7 @@ const App: React.FC = () => {
               Archive
             </button>
           </nav>
-           { (view === 'overview' || view === 'editor') && !isFullEditMode && view !== 'archive' && (
+           {(view === 'overview' || view === 'editor') && !isFullEditMode && (
             <div className="flex items-center p-1 bg-slate-800 rounded-md border border-slate-700" title="Toggle visibility of completed tasks">
               <label htmlFor="hide-completed-toggle" className="flex items-center cursor-pointer text-sm font-medium text-slate-300 select-none">
                 <div className="relative">
@@ -616,11 +622,11 @@ const App: React.FC = () => {
             isAuthenticated={isSupabaseAuthenticated}
             onSignOut={handleSignOut}
           />
-          {view !== 'archive' && 
+          {!isArchive &&
             <ProjectActions
                 viewScope={viewScope}
                 currentProject={currentProject}
-                isArchiveView={view === 'archive'}
+                isArchiveView={isArchive}
             />
           }
         </div>

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 This contains everything you need to run your app locally.
 
-View your app in AI Studio: https://ai.studio/apps/drive/1Qje4DjWE_pexg8CzPSHcUSbTEPUjG37C
+View your app in AI Studio: https://ai.studio/apps/drive/16s5Jq3k5LcVPdy5olmJmNwlxE5coJBo2
 
 ## Run Locally
 

--- a/components/FullDocumentEditor.tsx
+++ b/components/FullDocumentEditor.tsx
@@ -1,6 +1,3 @@
-
-
-
 import React, { useRef, useState, useCallback, useEffect } from 'react';
 import { Save, X } from 'lucide-react';
 import type { User } from '../types';
@@ -218,8 +215,8 @@ const FullDocumentEditor: React.FC<FullDocumentEditorProps> = ({ content, onChan
         case 'update': {
             const today = new Date().toISOString().split('T')[0];
             const textBeforeCursor = content.substring(0, selectionStart);
-            const atStartOfLine = selectionStart === 0 || textBeforeCursor.endsWith('\n');
-            insertion = `${atStartOfLine ? '' : '\n'}  - ${today}: `;
+            const needsNewline = selectionStart > 0 && !textBeforeCursor.endsWith('\n');
+            insertion = `${needsNewline ? '\n' : ''}  - ${today}: `;
             newCursorPos = selectionStart + insertion.length;
             break;
         }

--- a/components/InteractiveTaskItem.tsx
+++ b/components/InteractiveTaskItem.tsx
@@ -1,0 +1,448 @@
+import React, { useState, useCallback, useRef, useEffect, useMemo } from 'react';
+import type { User, TaskUpdate, Task, Heading, Project } from '../types';
+import Toolbar from './Toolbar';
+import { Pencil, Save, X, CheckCircle2, CalendarDays, ChevronRight, Archive, ChevronsUp, ChevronUp, ChevronDown, ChevronsDown } from 'lucide-react';
+import InputModal from './InputModal';
+import DatePickerModal from './DatePickerModal';
+import TaskReorderControls from './TaskReorderControls';
+
+// Re-usable parsing functions and components
+const parseInlineMarkdown = (text: string): React.ReactNode[] => {
+  const parts = text.split(/(\*\*.*?\*\*|\*.*?\*|\[.*?\]\(.*?\))/g);
+  return parts.map((part, index) => {
+    if (!part) return null;
+    if (part.startsWith('**') && part.endsWith('**')) return <strong key={index}>{part.slice(2, -2)}</strong>;
+    if (part.startsWith('*') && part.endsWith('*')) return <em key={index}>{part.slice(1, -1)}</em>;
+    const linkMatch = part.match(/\[(.*?)\]\((.*?)\)/);
+    if (linkMatch) return <a key={index} href={linkMatch[2]} target="_blank" rel="noopener noreferrer" className="text-indigo-400 hover:underline">{linkMatch[1]}</a>;
+    return part;
+  });
+};
+
+const InlineMarkdown: React.FC<{ text: string }> = ({ text }) => <>{parseInlineMarkdown(text)}</>;
+
+// InteractiveTaskItem Component
+interface InteractiveTaskItemProps {
+    task: Task;
+    taskBlockContent: string;
+    onToggle: (absoluteLineIndex: number, isCompleted: boolean) => void;
+    onUpdateTaskBlock: (absoluteStartLine: number, originalLineCount: number, newContent: string) => void;
+    users: User[];
+    isArchiveView?: boolean;
+    onArchiveTask: (task: Task) => void;
+    onReorderTask: (task: Task, direction: 'up' | 'down' | 'top' | 'bottom') => void;
+    taskIndexInList: number;
+    totalTasksInList: number;
+}
+
+const InteractiveTaskItem: React.FC<InteractiveTaskItemProps> = ({ task, taskBlockContent, onToggle, onUpdateTaskBlock, users, isArchiveView, onArchiveTask, onReorderTask, taskIndexInList, totalTasksInList }) => {
+  const [isEditing, setIsEditing] = useState(false);
+  const [editedContent, setEditedContent] = useState(taskBlockContent);
+  const [areUpdatesVisible, setAreUpdatesVisible] = useState(false);
+  const userByAlias = useMemo(() => new Map(users.map(u => [u.alias, u])), [users]);
+  const assignee = task.assigneeAlias ? userByAlias.get(task.assigneeAlias) : null;
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
+  
+  const [isInputModalOpen, setIsInputModalOpen] = useState(false);
+  const [inputModalConfig, setInputModalConfig] = useState<{
+      onSubmit: (value: string) => void;
+      title: string;
+      label: string;
+      confirmText: string;
+  } | null>(null);
+  const [isDatePickerOpen, setIsDatePickerOpen] = useState(false);
+
+  useEffect(() => {
+    if (!isEditing) {
+      setEditedContent(taskBlockContent);
+    }
+  }, [taskBlockContent, isEditing]);
+
+  useEffect(() => {
+    if (isEditing && textareaRef.current) {
+        const end = textareaRef.current.value.length;
+        textareaRef.current.focus();
+        textareaRef.current.setSelectionRange(end, end);
+    }
+  }, [isEditing]);
+
+  useEffect(() => {
+    if (isEditing && textareaRef.current) {
+        textareaRef.current.style.height = 'auto';
+        textareaRef.current.style.height = `${textareaRef.current.scrollHeight}px`;
+    }
+  }, [isEditing, editedContent]);
+
+  const handleSave = () => {
+    const originalLineCount = task.blockEndLine - task.lineIndex + 1;
+    onUpdateTaskBlock(task.lineIndex, originalLineCount, editedContent);
+    setIsEditing(false);
+  };
+
+  const handleCancel = () => {
+    setEditedContent(taskBlockContent);
+    setIsEditing(false);
+  };
+  
+  const handleInsertTextAtCursor = useCallback((text: string, type?: 'assignee') => {
+        const textarea = textareaRef.current;
+        if (!textarea) return;
+
+        const { selectionStart } = textarea;
+
+        if (type === 'assignee') {
+            const textBeforeCursor = editedContent.substring(0, selectionStart);
+            const lineStart = textBeforeCursor.lastIndexOf('\n') + 1;
+            
+            let lineEnd = editedContent.indexOf('\n', selectionStart);
+            if (lineEnd === -1) lineEnd = editedContent.length;
+
+            let currentLine = editedContent.substring(lineStart, lineEnd);
+            
+            const globalAssigneeRegex = /\s\(@([a-zA-Z0-9_]+)\)/g;
+            currentLine = currentLine.replace(globalAssigneeRegex, '');
+
+            const newCurrentLine = currentLine.trimEnd() + ' ' + text;
+
+            const newContent = editedContent.substring(0, lineStart) + newCurrentLine + editedContent.substring(lineEnd);
+            setEditedContent(newContent);
+
+            setTimeout(() => {
+                textarea.focus();
+                const newCursorPos = lineStart + newCurrentLine.length;
+                textarea.setSelectionRange(newCursorPos, newCursorPos);
+            }, 0);
+            return;
+        }
+
+        const { selectionEnd } = textarea;
+        const charBefore = selectionStart > 0 ? editedContent[selectionStart - 1] : '\n';
+        const spaceBefore = /\s$/.test(charBefore) ? '' : ' ';
+        const insertion = `${spaceBefore}${text}`;
+        
+        const newText = editedContent.substring(0, selectionStart) + insertion + editedContent.substring(selectionEnd);
+        
+        setEditedContent(newText);
+        
+        setTimeout(() => {
+            textarea.focus();
+            const newCursorPos = selectionStart + insertion.length;
+            textarea.setSelectionRange(newCursorPos, newCursorPos);
+        }, 0);
+    }, [editedContent]);
+
+      const handleDateSelect = useCallback((date: string) => {
+        const textarea = textareaRef.current;
+        if (!textarea) return;
+
+        const { selectionStart, selectionEnd } = textarea;
+        const charBefore = selectionStart > 0 ? editedContent[selectionStart - 1] : '\n';
+        const spaceBefore = /\s$/.test(charBefore) ? '' : ' ';
+        const insertion = `${spaceBefore}!${date}`;
+
+        const newText = editedContent.substring(0, selectionStart) + insertion + editedContent.substring(selectionEnd);
+        setEditedContent(newText);
+        
+        setTimeout(() => {
+            textarea.focus();
+            const newCursorPos = selectionStart + insertion.length;
+            textarea.setSelectionRange(newCursorPos, newCursorPos);
+        }, 0);
+    }, [editedContent]);
+
+
+  const handleFormat = useCallback((type: 'bold' | 'italic' | 'link' | 'gmail' | 'h1' | 'h2' | 'h3' | 'ul' | 'task' | 'update' | 'dueDate') => {
+    const textarea = textareaRef.current;
+    if (!textarea) return;
+    
+    const { selectionStart, selectionEnd } = textarea;
+    const selectedText = editedContent.substring(selectionStart, selectionEnd);
+    
+    if (type === 'link') {
+        setInputModalConfig({
+            title: 'Insert Link',
+            label: 'Enter the URL:',
+            confirmText: 'Insert Link',
+            onSubmit: (url) => {
+                const charBefore = selectionStart > 0 ? editedContent[selectionStart - 1] : '\n';
+                const charAfter = selectionEnd < editedContent.length ? editedContent[selectionEnd] : '\n';
+                const spaceBefore = /^\s$/.test(charBefore) ? '' : ' ';
+                const spaceAfter = /^\s$/.test(charAfter) ? '' : ' ';
+                
+                const linkText = selectedText || '🔗';
+                const safeUrl = url.replace(/\(/g, '%28').replace(/\)/g, '%29');
+                const insertion = spaceBefore + `[${linkText}](${safeUrl})` + spaceAfter;
+                const newText = editedContent.substring(0, selectionStart) + insertion + editedContent.substring(selectionEnd);
+                setEditedContent(newText);
+
+                setTimeout(() => {
+                    if (textareaRef.current) {
+                        textareaRef.current.focus();
+                        const selStart = selectionStart + spaceBefore.length + 1;
+                        const selEnd = selStart + linkText.length;
+                        textareaRef.current.setSelectionRange(selStart, selEnd);
+                    }
+                }, 0);
+            }
+        });
+        setIsInputModalOpen(true);
+        return;
+    }
+
+    if (type === 'gmail') {
+        setInputModalConfig({
+            title: 'Insert Gmail Link',
+            label: 'Enter the email subject:',
+            confirmText: 'Create Link',
+            onSubmit: (subject) => {
+                const charBefore = selectionStart > 0 ? editedContent[selectionStart - 1] : '\n';
+                const charAfter = selectionEnd < editedContent.length ? editedContent[selectionEnd] : '\n';
+                const spaceBefore = /^\s$/.test(charBefore) ? '' : ' ';
+                const spaceAfter = /^\s$/.test(charAfter) ? '' : ' ';
+
+                const encodedQuery = encodeURIComponent(`subject:"${subject}"`);
+                const searchUrl = `https://mail.google.com/mail/u/0/#search/${encodedQuery}`;
+                const safeSearchUrl = searchUrl.replace(/\(/g, '%28').replace(/\)/g, '%29');
+                const insertion = spaceBefore + `[📨 ${subject}](${safeSearchUrl})` + spaceAfter;
+                const newText = editedContent.substring(0, selectionStart) + insertion + editedContent.substring(selectionEnd);
+                setEditedContent(newText);
+
+                setTimeout(() => {
+                    if (textareaRef.current) {
+                        textareaRef.current.focus();
+                        const newCursorPos = selectionStart + insertion.length;
+                        textareaRef.current.setSelectionRange(newCursorPos, newCursorPos);
+                    }
+                }, 0);
+            }
+        });
+        setIsInputModalOpen(true);
+        return;
+    }
+    
+    if (type === 'dueDate') {
+        setIsDatePickerOpen(true);
+        return;
+    }
+
+
+    let prefix = '';
+    let suffix = '';
+    let insertion = '';
+    let newCursorPos = -1;
+    let newText;
+    
+    switch (type) {
+        case 'h1': prefix = '# '; break;
+        case 'h2': prefix = '## '; break;
+        case 'h3': prefix = '### '; break;
+        case 'bold': prefix = '**'; suffix = '**'; break;
+        case 'italic': prefix = '*'; suffix = '*'; break;
+        case 'ul': prefix = '- '; break;
+        case 'task': {
+            const today = new Date().toISOString().split('T')[0];
+            if (selectionStart !== selectionEnd) { // Multi-line selection
+                const newLines = selectedText.split('\n').map(line => {
+                    if (line.trim() === '') return line;
+                    if (line.trim().match(/^[-*] \[( |x)\]/)) return line;
+                    return `- [ ] ${line.trim()} +${today}`;
+                }).join('\n');
+                
+                newText = editedContent.substring(0, selectionStart) + newLines + editedContent.substring(selectionEnd);
+                setEditedContent(newText);
+                setTimeout(() => {
+                    if (textareaRef.current) {
+                        textareaRef.current.focus();
+                        textareaRef.current.setSelectionRange(selectionStart + newLines.length, selectionStart + newLines.length);
+                    }
+                }, 0);
+                return;
+            } else { // Single-line insertion
+                const textBeforeCursor = editedContent.substring(0, selectionStart);
+                const atEndOfNonEmptyLine = selectionStart > 0 && editedContent[selectionStart - 1] !== '\n';
+                prefix = (atEndOfNonEmptyLine ? '\n' : '') + '- [ ] ';
+                suffix = ` +${today}`;
+            }
+            break;
+        }
+        case 'update': {
+            const today = new Date().toISOString().split('T')[0];
+            const textBeforeCursor = editedContent.substring(0, selectionStart);
+            const needsNewline = selectionStart > 0 && !textBeforeCursor.endsWith('\n');
+            insertion = `${needsNewline ? '\n' : ''}  - ${today}: `;
+            newCursorPos = selectionStart + insertion.length;
+            break;
+        }
+    }
+
+    if (insertion) {
+        newText = editedContent.substring(0, selectionStart) + insertion + editedContent.substring(selectionEnd);
+    } else {
+        newText = editedContent.substring(0, selectionStart) + prefix + selectedText + suffix + editedContent.substring(selectionEnd);
+    }
+
+    setEditedContent(newText);
+    
+    setTimeout(() => {
+        if (textareaRef.current) {
+            textareaRef.current.focus();
+            if (newCursorPos !== -1) {
+                textareaRef.current.setSelectionRange(newCursorPos, newCursorPos);
+            } else if (selectedText.length === 0) {
+                 const cursorPos = selectionStart + prefix.length;
+                textareaRef.current.setSelectionRange(cursorPos, cursorPos);
+            } else {
+                 textareaRef.current.setSelectionRange(selectionStart + prefix.length, selectionEnd + prefix.length);
+            }
+        }
+    }, 0);
+
+  }, [editedContent]);
+
+
+  const getDueDateInfo = (dateString: string | null, isCompleted: boolean): { pillColor: string; label: string } | null => {
+      if (!dateString || isCompleted) return null;
+      const today = new Date(); today.setHours(0, 0, 0, 0); const due = new Date(`${dateString}T00:00:00`);
+      const diffTime = due.getTime() - today.getTime(); const diffDays = Math.ceil(diffTime / (1000 * 60 * 60 * 24));
+      if (diffDays < 0) return { pillColor: 'bg-red-500/20 text-red-400', label: `Overdue` };
+      if (diffDays === 0) return { pillColor: 'bg-yellow-500/20 text-yellow-400', label: 'Due today' };
+      return { pillColor: 'bg-slate-700/50 text-slate-300', label: `Due in ${diffDays} day(s)` };
+  };
+  const dueDateInfo = getDueDateInfo(task.dueDate, task.completed);
+  
+  if (isEditing) {
+    return (
+      <>
+        <div className="py-2 border-b border-indigo-500/30 bg-slate-800/30 rounded-lg p-3 my-2">
+          <div className="mb-2">
+            <Toolbar onFormat={handleFormat} onInsert={handleInsertTextAtCursor} users={users} />
+          </div>
+          <textarea
+            ref={textareaRef}
+            value={editedContent}
+            onChange={(e) => setEditedContent(e.target.value)}
+            className="w-full p-2 bg-slate-900 border border-slate-700 rounded-md resize-y focus:ring-2 focus:ring-indigo-500 outline-none font-mono text-sm leading-relaxed"
+            autoFocus
+          />
+          <div className="flex justify-end items-center mt-2 space-x-2">
+            <button onClick={handleCancel} className="px-3 py-1 rounded-md bg-slate-600 hover:bg-slate-500 font-semibold text-sm flex items-center space-x-2"><X className="w-4 h-4"/><span>Cancel</span></button>
+            <button onClick={handleSave} className="px-3 py-1 rounded-md bg-indigo-600 hover:bg-indigo-700 font-semibold text-sm flex items-center space-x-2"><Save className="w-4 h-4"/><span>Save</span></button>
+          </div>
+        </div>
+        {isInputModalOpen && inputModalConfig && (
+            <InputModal
+                isOpen={isInputModalOpen}
+                onClose={() => setIsInputModalOpen(false)}
+                onSubmit={inputModalConfig.onSubmit}
+                title={inputModalConfig.title}
+                label={inputModalConfig.label}
+                confirmText={inputModalConfig.confirmText}
+            />
+        )}
+        <DatePickerModal
+            isOpen={isDatePickerOpen}
+            onClose={() => setIsDatePickerOpen(false)}
+            onSelectDate={handleDateSelect}
+            title="Select Due Date"
+            confirmText="Insert Date"
+        />
+      </>
+    );
+  }
+
+  return (
+    <div className="py-2 border-b border-slate-800">
+        <div className="flex items-start space-x-3 group">
+            <input type="checkbox" checked={task.completed} onChange={(e) => onToggle(task.lineIndex, e.target.checked)} className="h-5 w-5 rounded-md bg-slate-700 border-slate-600 text-indigo-500 focus:ring-2 focus:ring-offset-2 focus:ring-offset-slate-900 focus:ring-indigo-500 cursor-pointer flex-shrink-0 mt-1" disabled={isArchiveView}/>
+            <div className="flex-grow min-w-0">
+                <div className="flex flex-wrap items-baseline gap-x-2 gap-y-1">
+                    <span className={`leading-snug ${task.completed ? 'line-through text-slate-500' : 'text-slate-200'}`}>
+                      <InlineMarkdown text={task.text} />
+                    </span>
+                    {assignee && (
+                      <div className="inline-flex items-center space-x-1.5 bg-slate-700/60 text-slate-300 px-1.5 py-0.5 rounded-full text-xs whitespace-nowrap" title={`Assigned to ${assignee.name}`}>
+                        <img src={assignee.avatarUrl} alt={assignee.name} className="h-4 w-4 rounded-full" />
+                        <span>{assignee.name}</span>
+                      </div>
+                    )}
+                    {dueDateInfo && (
+                      <div className={`inline-flex items-center space-x-1 px-1.5 py-0.5 rounded-full text-xs whitespace-nowrap ${dueDateInfo.pillColor}`} title={dueDateInfo.label}>
+                        <CalendarDays className="w-3 h-3" />
+                        <span>{task.dueDate}</span>
+                      </div>
+                    )}
+                     {task.cost !== undefined && (
+                      <span className="inline-flex items-center font-semibold bg-green-500/20 text-green-400 px-1.5 py-0.5 rounded-full text-xs whitespace-nowrap">
+                        ${task.cost.toFixed(2)}
+                      </span>
+                    )}
+                    {task.completionDate && task.completed && (
+                      <div className="inline-flex items-center space-x-1 bg-slate-700/60 text-slate-400 px-1.5 py-0.5 rounded-full text-xs whitespace-nowrap" title={`Completed on ${task.completionDate}`}>
+                        <CheckCircle2 className="w-3 h-3 text-green-500" />
+                        <span>{task.completionDate}</span>
+                      </div>
+                    )}
+                </div>
+            </div>
+            <div className="flex items-center flex-shrink-0 opacity-0 group-hover:opacity-100 transition-opacity duration-150">
+                {!isArchiveView && (
+                    <TaskReorderControls
+                        onReorder={(direction) => onReorderTask(task, direction)}
+                        canMoveUp={taskIndexInList > 0}
+                        canMoveDown={taskIndexInList < totalTasksInList - 1}
+                    />
+                )}
+                {!isArchiveView && task.completed && (
+                    <button 
+                        onClick={() => onArchiveTask(task)} 
+                        className="p-2 rounded-full hover:bg-slate-700 text-slate-400" 
+                        title="Archive task"
+                    >
+                        <Archive className="w-4 h-4" />
+                    </button>
+                )}
+                {!isArchiveView && (
+                    <button 
+                        onClick={() => setIsEditing(true)} 
+                        className="p-2 rounded-full hover:bg-slate-700 text-slate-400" 
+                        title="Edit task and updates"
+                    >
+                        <Pencil className="w-4 h-4" />
+                    </button>
+                )}
+            </div>
+        </div>
+        {task.updates.length > 0 && (
+            <>
+                <div className="pl-8 mt-2">
+                    <button
+                        onClick={() => setAreUpdatesVisible(v => !v)}
+                        className="flex items-center text-xs text-slate-400 hover:text-indigo-300 transition-colors py-1 rounded"
+                        aria-expanded={areUpdatesVisible}
+                        aria-controls={`updates-${task.lineIndex}`}
+                    >
+                        <ChevronRight className={`w-4 h-4 mr-1 transition-transform ${areUpdatesVisible ? 'rotate-90' : ''}`} />
+                        <span className="font-medium">{task.updates.length} update{task.updates.length > 1 ? 's' : ''}</span>
+                    </button>
+                </div>
+                {areUpdatesVisible && (
+                    <div id={`updates-${task.lineIndex}`} className="pl-8 mt-2 space-y-2 border-l-2 border-slate-800 ml-2.5">
+                        {task.updates.map(update => {
+                            const updateAssignee = update.assigneeAlias ? userByAlias.get(update.assigneeAlias) : null;
+                            return (
+                                <div key={update.lineIndex} className="flex items-center space-x-2 text-sm text-slate-400 w-full group">
+                                    {updateAssignee ? <img src={updateAssignee.avatarUrl} title={updateAssignee.name} className="w-5 h-5 rounded-full flex-shrink-0" alt={updateAssignee.name} /> : <div className="w-5 h-5 flex-shrink-0" />}
+                                    <span className="font-mono text-slate-500 whitespace-nowrap">{update.date}:</span>
+                                    <p className="flex-grow min-w-0"><InlineMarkdown text={update.text} /></p>
+                                </div>
+                            );
+                        })}
+                    </div>
+                )}
+            </>
+        )}
+    </div>
+  );
+};
+
+export default InteractiveTaskItem;

--- a/components/ProjectActions.tsx
+++ b/components/ProjectActions.tsx
@@ -1,5 +1,7 @@
 
 
+
+
 import React, { useState, useRef, useEffect, useCallback, useMemo } from 'react';
 import { BookUp, Upload, Download, FileText, CalendarDays } from 'lucide-react';
 import * as docx from 'docx';
@@ -145,7 +147,6 @@ const ProjectActions: React.FC<ProjectActionsProps> = ({ viewScope, currentProje
         projectsToExport.forEach((project, index) => {
             const allTasksInProject = [
                 ...project.unassignedTasks,
-                // FIX: Add explicit type to lambda parameter to fix 'tasks' property does not exist on type 'unknown' error.
                 ...Object.values(project.groupedTasks).flatMap((g: { user: User; tasks: Task[] }) => g.tasks)
             ];
 
@@ -326,7 +327,6 @@ const ProjectActions: React.FC<ProjectActionsProps> = ({ viewScope, currentProje
         if (viewScope === 'all') {
             projects.forEach(project => {
                 taskSummaryChildren.push(new docx.Paragraph({ text: project.title, heading: docx.HeadingLevel.HEADING_2, spacing: { before: 400, after: 200 } }));
-                // FIX: Add explicit type to lambda parameter to fix 'tasks' property does not exist on type 'unknown' error.
                 const assignedUsersWithTasks = Object.values(project.groupedTasks).filter((g: { user: User; tasks: Task[] }) => g.tasks.length > 0);
                  assignedUsersWithTasks.forEach(({ user, tasks }) => {
                     taskSummaryChildren.push(new docx.Paragraph({ text: user.name, heading: docx.HeadingLevel.HEADING_3, spacing: { before: 300, after: 150 } }));
@@ -340,7 +340,6 @@ const ProjectActions: React.FC<ProjectActionsProps> = ({ viewScope, currentProje
             });
         } else { 
             taskSummaryChildren.push(new docx.Paragraph({ text: currentProject.title, heading: docx.HeadingLevel.HEADING_2, spacing: { before: 400, after: 200 } }));
-            // FIX: Add explicit type to lambda parameter to fix 'tasks' property does not exist on type 'unknown' error.
             const assignedUsersWithTasks = Object.values(currentProject.groupedTasks).filter((g: { user: User; tasks: Task[] }) => g.tasks.length > 0);
             assignedUsersWithTasks.forEach(({ user, tasks }) => {
                 taskSummaryChildren.push(new docx.Paragraph({ text: user.name, heading: docx.HeadingLevel.HEADING_3, spacing: { before: 300, after: 150 } }));

--- a/components/ProjectOverview.tsx
+++ b/components/ProjectOverview.tsx
@@ -1,5 +1,7 @@
 
 
+
+
 import React, { useState, useMemo, useCallback } from 'react';
 import type { User, Task, GroupedTasks, Settings } from '../types';
 import { CheckCircle2, Circle, Users, Mail, DollarSign, ListChecks, BarChart2, CalendarDays, Pencil } from 'lucide-react';

--- a/components/TaskEditModal.tsx
+++ b/components/TaskEditModal.tsx
@@ -1,6 +1,3 @@
-
-
-
 import React, { useState, useEffect, useRef, useCallback, useMemo } from 'react';
 import { X, Save } from 'lucide-react';
 import type { User, Task } from '../types';
@@ -245,8 +242,8 @@ const TaskEditModal: React.FC<TaskEditModalProps> = ({ isOpen, onClose, task }) 
         case 'update': {
             const today = new Date().toISOString().split('T')[0];
             const textBeforeCursor = content.substring(0, selectionStart);
-            const atStartOfLine = selectionStart === 0 || textBeforeCursor.endsWith('\n');
-            insertion = `${atStartOfLine ? '' : '\n'}  - ${today}: `;
+            const needsNewline = selectionStart > 0 && !textBeforeCursor.endsWith('\n');
+            insertion = `${needsNewline ? '\n' : ''}  - ${today}: `;
             newCursorPos = selectionStart + insertion.length;
             break;
         }

--- a/components/TaskReorderControls.tsx
+++ b/components/TaskReorderControls.tsx
@@ -1,0 +1,46 @@
+import React from 'react';
+import { ChevronsUp, ChevronUp, ChevronDown, ChevronsDown } from 'lucide-react';
+
+interface TaskReorderControlsProps {
+  onReorder: (direction: 'up' | 'down' | 'top' | 'bottom') => void;
+  canMoveUp: boolean;
+  canMoveDown: boolean;
+}
+
+const ReorderButton: React.FC<{
+  onClick: () => void;
+  disabled: boolean;
+  title: string;
+  children: React.ReactNode;
+}> = ({ onClick, disabled, title, children }) => (
+  <button
+    onClick={onClick}
+    disabled={disabled}
+    className="p-1.5 rounded-md text-slate-400 hover:bg-slate-700 hover:text-slate-100 disabled:text-slate-600 disabled:cursor-not-allowed disabled:hover:bg-transparent"
+    title={title}
+  >
+    {children}
+  </button>
+);
+
+const TaskReorderControls: React.FC<TaskReorderControlsProps> = ({ onReorder, canMoveUp, canMoveDown }) => {
+  return (
+    <div className="flex items-center border border-slate-700 bg-slate-800/50 rounded-md mr-1">
+      <ReorderButton onClick={() => onReorder('top')} disabled={!canMoveUp} title="Move to top of list">
+        <ChevronsUp className="w-4 h-4" />
+      </ReorderButton>
+      <ReorderButton onClick={() => onReorder('up')} disabled={!canMoveUp} title="Move up">
+        <ChevronUp className="w-4 h-4" />
+      </ReorderButton>
+      <div className="w-px h-4 bg-slate-700"></div>
+      <ReorderButton onClick={() => onReorder('down')} disabled={!canMoveDown} title="Move down">
+        <ChevronDown className="w-4 h-4" />
+      </ReorderButton>
+      <ReorderButton onClick={() => onReorder('bottom')} disabled={!canMoveDown} title="Move to bottom of list">
+        <ChevronsDown className="w-4 h-4" />
+      </ReorderButton>
+    </div>
+  );
+};
+
+export default TaskReorderControls;

--- a/hooks/useMarkdownParser.ts
+++ b/hooks/useMarkdownParser.ts
@@ -1,7 +1,11 @@
-
-
 import { useMemo } from 'react';
 import { User, Task, GroupedTasks, TaskUpdate, Project, Heading } from '../types';
+import { remark } from 'remark';
+import remarkParse from 'remark-parse';
+import remarkGfm from 'remark-gfm';
+import { visit } from 'unist-util-visit';
+import { toString } from 'mdast-util-to-string';
+import type { Root, Heading as MdastHeading, ListItem, Paragraph } from 'mdast';
 
 const slugify = (text: string, existingSlugs: Set<string>): string => {
   let slug = text.toLowerCase().trim()
@@ -31,156 +35,156 @@ const slugify = (text: string, existingSlugs: Set<string>): string => {
 export const useMarkdownParser = (markdown: string, users: User[]): Project[] => {
     return useMemo(() => {
         const lines = markdown.split('\n');
-        const projects: Project[] = [];
+        const processor = remark().use(remarkParse).use(remarkGfm);
+        const tree = processor.parse(markdown) as Root;
+        const existingSlugs = new Set<string>();
         
+        // Step 1: Initialize projects based on H1 headings
+        let projects: Project[] = [];
         const projectBoundaries: { title: string, startLine: number }[] = [];
 
-        lines.forEach((line, index) => {
-            const h1Match = line.match(/^# (.*)/);
-            if (h1Match) {
-                projectBoundaries.push({ title: h1Match[1].trim(), startLine: index });
+        visit(tree, 'heading', (node: MdastHeading) => {
+            if (node.depth === 1 && node.position) {
+                projectBoundaries.push({
+                    title: toString(node).trim(),
+                    startLine: node.position.start.line - 1,
+                });
             }
         });
 
         if (projectBoundaries.length === 0) {
-            projectBoundaries.push({ title: 'Project Overview', startLine: 0 });
+            projects.push({ title: 'Project Overview', startLine: 0, endLine: lines.length - 1, headings: [], groupedTasks: {}, unassignedTasks: [], totalCost: 0 });
+        } else {
+            projectBoundaries.forEach((boundary, idx) => {
+                const endLine = (idx + 1 < projectBoundaries.length) ? projectBoundaries[idx + 1].startLine - 1 : lines.length - 1;
+                projects.push({ title: boundary.title, startLine: boundary.startLine, endLine: endLine, headings: [], groupedTasks: {}, unassignedTasks: [], totalCost: 0 });
+            });
         }
 
-        const existingSlugs = new Set<string>();
+        // Initialize user groups for each project
+        projects.forEach(p => {
+            p.groupedTasks = users.reduce((acc, user) => ({ ...acc, [user.alias]: { user, tasks: [] } }), {} as GroupedTasks);
+        });
 
-        projectBoundaries.forEach((boundary, idx) => {
-            const startLine = boundary.startLine;
-            const endLine = (idx + 1 < projectBoundaries.length) ? projectBoundaries[idx + 1].startLine - 1 : lines.length - 1;
+        // Step 2: Traverse the tree to find headings and tasks
+        const headingStack: { text: string; level: number }[] = [];
+        
+        const assigneeRegex = /\s\(@([a-zA-Z0-9_]+)\)/;
+        const dateRegex = /\s~([0-9]{4}-[0-9]{2}-[0-9]{2})/;
+        const costRegex = /\s\(\$(\d+(\.\d{1,2})?)\)/;
+        const creationDateRegex = /\s\+([0-9]{4}-[0-9]{2}-[0-9]{2})/;
+        const dueDateRegex = /\s!([0-9]{4}-[0-9]{2}-[0-9]{2})/;
+        const updateContentRegex = /^(\d{4}-\d{2}-\d{2}): (.*)/;
+
+
+        visit(tree, (node) => {
+            if (!node.position) return;
             
-            const projectLines = lines.slice(startLine, endLine + 1);
-            const currentProjectTasks: Task[] = [];
-            const currentProjectHeadings: Heading[] = [];
-            
-            const taskRegex = /^- \[( |x)\] (.*)/;
-            const assigneeRegex = /\s\(@([a-zA-Z0-9_]+)\)/;
-            const dateRegex = /\s~([0-9]{4}-[0-9]{2}-[0-9]{2})/;
-            const costRegex = /\s\(\$(\d+(\.\d{1,2})?)\)/;
-            const creationDateRegex = /\s\+([0-9]{4}-[0-9]{2}-[0-9]{2})/;
-            const dueDateRegex = /\s!([0-9]{4}-[0-9]{2}-[0-9]{2})/;
-            const updateRegex = /^  - (\d{4}-\d{2}-\d{2}): (.*)/;
-            
-            let i = 0;
-            let currentHeading: Heading | null = null;
-
-            while (i < projectLines.length) {
-                const line = projectLines[i];
-                const absoluteLineIndex = startLine + i;
-
-                const hMatch = line.match(/^(#+) (.*)/);
-                if (hMatch) {
-                    const level = hMatch[1].length;
-                    const text = hMatch[2].trim();
-                    const headingData: Heading = {
-                        text,
-                        slug: slugify(text, existingSlugs),
-                        level,
-                        line: absoluteLineIndex,
-                    };
-
-                    currentHeading = headingData;
-                    if (level <= 3) {
-                         currentProjectHeadings.push(headingData);
-                    }
-                }
-                
-                const taskMatch = line.match(taskRegex);
-
-                if (taskMatch) {
-                    let fullTaskText = taskMatch[2];
-                    let assigneeAlias: string | null = null;
-                    let completionDate: string | null = null;
-                    let creationDate: string | null = null;
-                    let cost: number | undefined = undefined;
-                    let dueDate: string | null = null;
-
-                    const dateMatch = fullTaskText.match(dateRegex);
-                    if (dateMatch) { completionDate = dateMatch[1]; fullTaskText = fullTaskText.replace(dateRegex, '').trim(); }
-                    
-                    const costMatch = fullTaskText.match(costRegex);
-                    if (costMatch) { cost = parseFloat(costMatch[1]); fullTaskText = fullTaskText.replace(costRegex, '').trim(); }
-
-                    const assigneeMatch = fullTaskText.match(assigneeRegex);
-                    if (assigneeMatch) { assigneeAlias = assigneeMatch[1]; fullTaskText = fullTaskText.replace(assigneeRegex, '').trim(); }
-                    
-                    const creationDateMatch = fullTaskText.match(creationDateRegex);
-                    if (creationDateMatch) { creationDate = creationDateMatch[1]; fullTaskText = fullTaskText.replace(creationDateRegex, '').trim(); }
-
-                    const dueDateMatch = fullTaskText.match(dueDateRegex);
-                    if (dueDateMatch) { dueDate = dueDateMatch[1]; fullTaskText = fullTaskText.replace(dueDateRegex, '').trim(); }
-
-                    const updates: TaskUpdate[] = [];
-                    let j = i + 1;
-                    while (j < projectLines.length) {
-                        const updateLine = projectLines[j];
-                        const updateMatch = updateLine.match(updateRegex);
-                        if (updateMatch) {
-                            let updateText = updateMatch[2].trim();
-                            let updateAssigneeAlias: string | null = null;
-                            const updateAssigneeMatch = updateText.match(assigneeRegex);
-                            if(updateAssigneeMatch){ updateAssigneeAlias = updateAssigneeMatch[1]; updateText = updateText.replace(assigneeRegex, '').trim(); }
-                            
-                            updates.push({
-                                lineIndex: startLine + j,
-                                date: updateMatch[1],
-                                text: updateText,
-                                assigneeAlias: updateAssigneeAlias,
-                            });
-                            j++;
-                        } else {
-                             if (updateLine.trim() !== '') break;
-                             j++;
-                        }
-                    }
-                    
-                    currentProjectTasks.push({
-                        lineIndex: absoluteLineIndex,
-                        text: fullTaskText,
-                        completed: taskMatch[1] === 'x',
-                        assigneeAlias,
-                        creationDate,
-                        completionDate,
-                        dueDate,
-                        updates,
-                        projectTitle: boundary.title,
-                        cost,
-                        blockEndLine: startLine + (j - 1),
-                        sectionTitle: currentHeading?.text,
-                        sectionSlug: currentHeading?.slug,
-                    });
-                    i = j;
-                } else {
-                    i++;
-                }
+            const nodeLine = node.position.start.line - 1;
+            const projectIdx = projects.findIndex(p => nodeLine >= p.startLine && nodeLine <= p.endLine);
+            if (projectIdx === -1 && projects.length === 1 && projects[0].title === 'Project Overview') {
+                // Fallback for file without H1
+            } else if (projectIdx === -1) {
+                return;
             }
 
-            const groupedTasks: GroupedTasks = users.reduce((acc, user) => ({ ...acc, [user.alias]: { user, tasks: [] } }), {} as GroupedTasks);
-            const unassignedTasks: Task[] = [];
-            let totalCost = 0;
-            currentProjectTasks.forEach(task => {
-                if (task.cost) totalCost += task.cost;
-                if (task.assigneeAlias && groupedTasks[task.assigneeAlias]) {
-                    groupedTasks[task.assigneeAlias].tasks.push(task);
-                } else {
-                    unassignedTasks.push(task);
-                }
-            });
 
-            projects.push({
-                title: boundary.title,
-                groupedTasks,
-                unassignedTasks,
-                totalCost,
-                startLine,
-                endLine,
-                headings: currentProjectHeadings,
-            });
+            if (node.type === 'heading') {
+                const level = node.depth;
+                const text = toString(node).trim();
+
+                while (headingStack.length > 0 && headingStack[headingStack.length - 1].level >= level) {
+                    headingStack.pop();
+                }
+                headingStack.push({ text, level });
+
+                const headingData: Heading = { text, slug: slugify(text, existingSlugs), level, line: node.position.start.line - 1 };
+                if (level > 1 && level <= 3) {
+                     projects[projectIdx].headings.push(headingData);
+                }
+            }
+            
+            if (node.type === 'listItem' && typeof node.checked === 'boolean') {
+                const paragraphNode = node.children.find(child => child.type === 'paragraph') as Paragraph | undefined;
+                if (!paragraphNode) return;
+
+                let fullTaskText = toString(paragraphNode);
+                let assigneeAlias: string | null = null;
+                let completionDate: string | null = null;
+                let creationDate: string | null = null;
+                let cost: number | undefined = undefined;
+                let dueDate: string | null = null;
+
+                const dateMatch = fullTaskText.match(dateRegex);
+                if (dateMatch) { completionDate = dateMatch[1]; fullTaskText = fullTaskText.replace(dateRegex, '').trim(); }
+                
+                const costMatch = fullTaskText.match(costRegex);
+                if (costMatch) { cost = parseFloat(costMatch[1]); fullTaskText = fullTaskText.replace(costRegex, '').trim(); }
+
+                const assigneeMatch = fullTaskText.match(assigneeRegex);
+                if (assigneeMatch) { assigneeAlias = assigneeMatch[1]; fullTaskText = fullTaskText.replace(assigneeRegex, '').trim(); }
+                
+                const creationDateMatch = fullTaskText.match(creationDateRegex);
+                if (creationDateMatch) { creationDate = creationDateMatch[1]; fullTaskText = fullTaskText.replace(creationDateRegex, '').trim(); }
+
+                const dueDateMatch = fullTaskText.match(dueDateRegex);
+                if (dueDateMatch) { dueDate = dueDateMatch[1]; fullTaskText = fullTaskText.replace(dueDateRegex, '').trim(); }
+
+                const updates: TaskUpdate[] = [];
+                visit(node, 'list', (listNode) => {
+                    visit(listNode, 'listItem', (updateItemNode: ListItem) => {
+                        if (updateItemNode.position) {
+                            const updateTextContent = toString(updateItemNode);
+                            const updateMatch = updateTextContent.match(updateContentRegex);
+
+                            if (updateMatch) {
+                                let updateText = updateMatch[2].trim();
+                                let updateAssigneeAlias: string | null = null;
+                                const updateAssigneeMatch = updateText.match(assigneeRegex);
+                                if(updateAssigneeMatch){ updateAssigneeAlias = updateAssigneeMatch[1]; updateText = updateText.replace(assigneeRegex, '').trim(); }
+
+                                updates.push({
+                                    lineIndex: updateItemNode.position.start.line - 1,
+                                    date: updateMatch[1],
+                                    text: updateText,
+                                    assigneeAlias: updateAssigneeAlias,
+                                });
+                            }
+                        }
+                    });
+                    // Stop recursion into deeper nested lists
+                    return 'skip';
+                });
+                
+                const currentProjectTitle = projects[projectIdx]?.title || 'Project Overview';
+                const sectionHeading = headingStack.length > 1 ? headingStack[headingStack.length - 1] : null;
+
+                const task: Task = {
+                    lineIndex: node.position.start.line - 1,
+                    text: fullTaskText,
+                    completed: node.checked,
+                    assigneeAlias,
+                    creationDate,
+                    completionDate,
+                    dueDate,
+                    updates,
+                    projectTitle: currentProjectTitle,
+                    cost,
+                    blockEndLine: node.position.end.line - 1,
+                    sectionTitle: sectionHeading?.text,
+                    sectionSlug: sectionHeading ? slugify(sectionHeading.text, new Set()) : undefined, // slug here is just for convenience, not for TOC
+                    headingHierarchy: [...headingStack],
+                };
+                
+                if (task.cost) projects[projectIdx].totalCost += task.cost;
+                if (task.assigneeAlias && projects[projectIdx].groupedTasks[task.assigneeAlias]) {
+                    projects[projectIdx].groupedTasks[task.assigneeAlias].tasks.push(task);
+                } else {
+                    projects[projectIdx].unassignedTasks.push(task);
+                }
+            }
         });
-        
+
         return projects;
     }, [markdown, users]);
 };

--- a/index.html
+++ b/index.html
@@ -16,7 +16,14 @@
     "jspdf": "https://aistudiocdn.com/jspdf@^2.5.1",
     "docx": "https://aistudiocdn.com/docx@^8.5.0",
     "file-saver": "https://aistudiocdn.com/file-saver@^2.0.5",
-    "@supabase/supabase-js": "https://aistudiocdn.com/@supabase/supabase-js@^2.45.0"
+    "@supabase/supabase-js": "https://aistudiocdn.com/@supabase/supabase-js@^2.45.0",
+    "remark": "https://esm.sh/remark@15.0.1",
+    "remark-parse": "https://esm.sh/remark-parse@11.0.0",
+    "remark-gfm": "https://esm.sh/remark-gfm@4.0.0",
+    "unist-util-visit": "https://esm.sh/unist-util-visit@5.0.0",
+    "mdast-util-to-string": "https://esm.sh/mdast-util-to-string@4.0.0",
+    "mdast": "https://aistudiocdn.com/mdast@^3.0.0",
+    "remark-stringify": "https://esm.sh/remark-stringify@11.0.0"
   }
 }
 </script>

--- a/lib/supabaseClient.ts
+++ b/lib/supabaseClient.ts
@@ -1,8 +1,8 @@
+
 import { createClient, SupabaseClient, User, Session } from '@supabase/supabase-js';
 import type { FullProjectState, BackupRecord } from '../types';
 
 let supabase: SupabaseClient | null = null;
-// FIX: Cache the supabase URL to avoid accessing a protected property on the client.
 let supabaseUrlCache: string | null = null;
 
 export const getSupabaseClient = (url: string, anonKey: string): SupabaseClient => {

--- a/metadata.json
+++ b/metadata.json
@@ -1,5 +1,5 @@
 {
-  "name": "Interactive Markdown Tasker",
+  "name": "Markdown Tasker v2",
   "description": "A markdown editor that allows you to create task lists and assign tasks to users directly from the preview. Unlike classic markdown, this tool lets you intercept tasks and assign them to specific people.",
   "requestFramePermissions": []
 }

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "interactive-markdown-tasker",
+  "name": "markdown-tasker-v2",
   "private": true,
   "version": "0.0.0",
   "type": "module",
@@ -15,7 +15,14 @@
     "jspdf": "^2.5.1",
     "docx": "^8.5.0",
     "file-saver": "^2.0.5",
-    "@supabase/supabase-js": "^2.45.0"
+    "@supabase/supabase-js": "^2.45.0",
+    "remark": "15.0.1",
+    "remark-parse": "11.0.0",
+    "remark-gfm": "4.0.0",
+    "unist-util-visit": "5.0.0",
+    "mdast-util-to-string": "4.0.0",
+    "mdast": "^3.0.0",
+    "remark-stringify": "11.0.0"
   },
   "devDependencies": {
     "@types/node": "^22.14.0",

--- a/types.ts
+++ b/types.ts
@@ -28,6 +28,7 @@ export interface Task {
   blockEndLine: number;
   sectionTitle?: string;
   sectionSlug?: string;
+  headingHierarchy: { text: string; level: number; }[];
 }
 
 export interface GroupedTasks {


### PR DESCRIPTION
This commit introduces the `remark` ecosystem for more robust markdown parsing. This includes:
- `remark-parse` for parsing markdown into an Abstract Syntax Tree (AST).
- `remark-gfm` for GitHub Flavored Markdown support.
- `unist-util-visit` for traversing the AST.
- `mdast-util-to-string` for extracting text content.
- `mdast` and `remark-stringify` for AST manipulation and generation.

The integration allows for better identification of headings, list items, and other markdown elements, laying the groundwork for future enhancements in task extraction and manipulation. The project name has also been updated to `markdown-tasker-v2` across package.json and metadata.json.