### PR TITLE
feat: Add project slugs for navigation

### DIFF
--- a/components/EditableSection.tsx
+++ b/components/EditableSection.tsx
@@ -132,7 +132,8 @@ const EditableSection: React.FC<EditableSectionProps> = (props) => {
     
     const allProjectTasks = [
         ...project.unassignedTasks,
-        ...Object.values(project.groupedTasks).flatMap((g) => g.tasks)
+        // FIX: Add explicit type for 'g' to resolve TS error.
+        ...Object.values(project.groupedTasks).flatMap((g: { user: User; tasks: Task[] }) => g.tasks)
     ];
 
     const sectionAbsoluteStart = projectStartLine + section.startLine;
@@ -499,7 +500,8 @@ const EditableSection: React.FC<EditableSectionProps> = (props) => {
         const projectForTask = project;
         if (projectForTask) {
             const absoluteLineIndex = projectStartLine + section.startLine + startIndex;
-            const taskFromContext = [...projectForTask.unassignedTasks, ...Object.values(projectForTask.groupedTasks).flatMap(g => g.tasks)].find(t => t.lineIndex === absoluteLineIndex);
+            // FIX: Add explicit type for 'g' to resolve TS error.
+            const taskFromContext = [...projectForTask.unassignedTasks, ...Object.values(projectForTask.groupedTasks).flatMap((g: { user: User, tasks: Task[] }) => g.tasks)].find(t => t.lineIndex === absoluteLineIndex);
             if (taskFromContext) {
                  assignee = taskFromContext.assigneeAlias ? userByAlias.get(taskFromContext.assigneeAlias) ?? null : null;
                  completionDate = taskFromContext.completionDate;
@@ -615,6 +617,13 @@ const EditableSection: React.FC<EditableSectionProps> = (props) => {
             const text = hMatch[2].trim();
             const headingData = tocHeadingsForSlugs?.find(h => h.line === (viewScope === 'single' && !isArchiveView ? relativeLineIndex + project.startLine : relativeLineIndex));
             
+            let slugForId: string | undefined;
+            if (level === 1) {
+                slugForId = project?.slug;
+            } else {
+                slugForId = headingData?.slug;
+            }
+            
             let headingClassName: string;
             let buttonClassName = "font-bold flex items-center w-full text-left transition-colors hover:text-slate-100 focus:outline-none focus:ring-2 focus:ring-indigo-500 rounded p-1 -ml-1";
             
@@ -625,7 +634,7 @@ const EditableSection: React.FC<EditableSectionProps> = (props) => {
             }
   
             const HeadingTag = `h${level}`;
-            elements.push(React.createElement(HeadingTag, { key: i, id: headingData?.slug, className: headingClassName },
+            elements.push(React.createElement(HeadingTag, { key: i, id: slugForId, className: headingClassName },
                 <button className={buttonClassName} onClick={onToggleCollapse} aria-expanded={!isCollapsed} aria-controls={`section-content-${section.startLine}`}>
                     {isCollapsed ? <ChevronRight className="w-5 h-5 mr-2 flex-shrink-0 text-slate-400" /> : <ChevronDown className="w-5 h-5 mr-2 flex-shrink-0 text-slate-400" />}
                     <span className="flex-grow"><InlineMarkdown text={text} /></span>

--- a/components/ProjectOverview.tsx
+++ b/components/ProjectOverview.tsx
@@ -1,7 +1,4 @@
 
-
-
-
 import React, { useState, useMemo, useCallback } from 'react';
 import type { User, Task, GroupedTasks, Settings } from '../types';
 import { CheckCircle2, Circle, Users, Mail, DollarSign, ListChecks, BarChart2, CalendarDays, Pencil } from 'lucide-react';
@@ -75,11 +72,6 @@ const TaskItem: React.FC<{
   
     const dueDateInfo = getDueDateInfo(task.dueDate, task.completed);
     
-    const contextPath = [
-        viewScope === 'all' ? task.projectTitle : null,
-        task.sectionTitle
-    ].filter(Boolean).join(' > ');
-
     return (
       <div className="flex items-start space-x-3 group relative">
         {task.completed ? (
@@ -102,17 +94,42 @@ const TaskItem: React.FC<{
                 {dueDateInfo.label}
              </span>
            )}
-           {contextPath && task.sectionSlug ? (
-              <button 
-                onClick={() => onNavigate(task.projectTitle, task.sectionSlug!)} 
-                className="block text-xs text-indigo-400 font-medium mt-1 hover:underline text-left"
-                title={`Go to section: ${task.sectionTitle}`}
-              >
-                {contextPath}
-              </button>
-            ) : viewScope === 'all' ? (
-              <span className="block text-xs text-slate-500 font-medium mt-1">{task.projectTitle}</span>
-            ) : null}
+           {(() => {
+              const contextPath = [
+                  viewScope === 'all' ? task.projectTitle : null,
+                  task.sectionTitle
+              ].filter(Boolean).join(' > ');
+
+              if (task.sectionSlug) {
+                  return (
+                      <button 
+                        onClick={() => onNavigate(task.projectTitle, task.sectionSlug!)} 
+                        className="block text-xs text-indigo-400 font-medium mt-1 hover:underline text-left"
+                        title={`Go to section: ${task.sectionTitle}`}
+                      >
+                        {contextPath}
+                      </button>
+                  );
+              }
+              
+              if (viewScope === 'all' && task.projectSlug) {
+                  return (
+                      <button 
+                        onClick={() => onNavigate(task.projectTitle, task.projectSlug!)} 
+                        className="block text-xs text-indigo-400 font-medium mt-1 hover:underline text-left"
+                        title={`Go to project: ${task.projectTitle}`}
+                      >
+                        {task.projectTitle}
+                      </button>
+                  );
+              }
+              
+              if (viewScope === 'all') {
+                  return <span className="block text-xs text-slate-500 font-medium mt-1">{task.projectTitle}</span>;
+              }
+
+              return null;
+          })()}
           {task.creationDate && (
             <span className="block text-xs text-slate-400">
               Created: {task.creationDate}

--- a/components/TimelineView.tsx
+++ b/components/TimelineView.tsx
@@ -25,11 +25,6 @@ const parseInlineMarkdown = (text: string): React.ReactNode[] => {
 const InlineMarkdown: React.FC<{ text: string }> = ({ text }) => <>{parseInlineMarkdown(text)}</>;
 
 const TimelineTaskItem: React.FC<{ task: Task; user: User | null; viewScope: ViewScope; onNavigate: (projectTitle: string, sectionSlug: string) => void; }> = ({ task, user, viewScope, onNavigate }) => {
-  const contextPath = [
-    viewScope === 'all' ? task.projectTitle : null,
-    task.sectionTitle
-  ].filter(Boolean).join(' > ');
-  
   return (
     <div className="flex items-start space-x-3 p-3 bg-slate-800/50 rounded-md">
       {task.completed ? (
@@ -49,17 +44,42 @@ const TimelineTaskItem: React.FC<{ task: Task; user: User | null; viewScope: Vie
             </div>
           )}
         </div>
-        {contextPath && task.sectionSlug ? (
-          <button 
-            onClick={() => onNavigate(task.projectTitle, task.sectionSlug!)} 
-            className="block text-xs text-indigo-400 font-medium mt-1 hover:underline text-left"
-            title={`Go to section: ${task.sectionTitle}`}
-          >
-            {contextPath}
-          </button>
-        ) : viewScope === 'all' ? (
-          <span className="block text-xs text-slate-500 font-medium mt-1">{task.projectTitle}</span>
-        ) : null}
+        {(() => {
+            const contextPath = [
+                viewScope === 'all' ? task.projectTitle : null,
+                task.sectionTitle
+            ].filter(Boolean).join(' > ');
+
+            if (task.sectionSlug) {
+                return (
+                    <button 
+                      onClick={() => onNavigate(task.projectTitle, task.sectionSlug!)} 
+                      className="block text-xs text-indigo-400 font-medium mt-1 hover:underline text-left"
+                      title={`Go to section: ${task.sectionTitle}`}
+                    >
+                      {contextPath}
+                    </button>
+                );
+            }
+            
+            if (viewScope === 'all' && task.projectSlug) {
+                return (
+                    <button 
+                      onClick={() => onNavigate(task.projectTitle, task.projectSlug!)} 
+                      className="block text-xs text-indigo-400 font-medium mt-1 hover:underline text-left"
+                      title={`Go to project: ${task.projectTitle}`}
+                    >
+                      {task.projectTitle}
+                    </button>
+                );
+            }
+            
+            if (viewScope === 'all') {
+                return <span className="block text-xs text-slate-500 font-medium mt-1">{task.projectTitle}</span>;
+            }
+
+            return null;
+        })()}
       </div>
       <span className="text-xs font-mono whitespace-nowrap text-slate-400">{task.dueDate}</span>
     </div>

--- a/hooks/useMarkdownParser.ts
+++ b/hooks/useMarkdownParser.ts
@@ -53,11 +53,12 @@ export const useMarkdownParser = (markdown: string, users: User[]): Project[] =>
         });
 
         if (projectBoundaries.length === 0) {
-            projects.push({ title: 'Project Overview', startLine: 0, endLine: lines.length - 1, headings: [], groupedTasks: {}, unassignedTasks: [], totalCost: 0 });
+            projects.push({ title: 'Project Overview', slug: 'project-overview', startLine: 0, endLine: lines.length - 1, headings: [], groupedTasks: {}, unassignedTasks: [], totalCost: 0 });
         } else {
             projectBoundaries.forEach((boundary, idx) => {
                 const endLine = (idx + 1 < projectBoundaries.length) ? projectBoundaries[idx + 1].startLine - 1 : lines.length - 1;
-                projects.push({ title: boundary.title, startLine: boundary.startLine, endLine: endLine, headings: [], groupedTasks: {}, unassignedTasks: [], totalCost: 0 });
+                const slug = slugify(boundary.title, existingSlugs);
+                projects.push({ title: boundary.title, slug, startLine: boundary.startLine, endLine: endLine, headings: [], groupedTasks: {}, unassignedTasks: [], totalCost: 0 });
             });
         }
 
@@ -156,7 +157,8 @@ export const useMarkdownParser = (markdown: string, users: User[]): Project[] =>
                     return 'skip';
                 });
                 
-                const currentProjectTitle = projects[projectIdx]?.title || 'Project Overview';
+                const currentProject = projects[projectIdx];
+                const currentProjectTitle = currentProject?.title || 'Project Overview';
                 const sectionHeading = headingStack.length > 1 ? headingStack[headingStack.length - 1] : null;
 
                 const task: Task = {
@@ -169,6 +171,7 @@ export const useMarkdownParser = (markdown: string, users: User[]): Project[] =>
                     dueDate,
                     updates,
                     projectTitle: currentProjectTitle,
+                    projectSlug: currentProject?.slug,
                     cost,
                     blockEndLine: node.position.end.line - 1,
                     sectionTitle: sectionHeading?.text,

--- a/types.ts
+++ b/types.ts
@@ -24,6 +24,7 @@ export interface Task {
   dueDate?: string | null;
   updates: TaskUpdate[];
   projectTitle: string;
+  projectSlug?: string;
   cost?: number;
   blockEndLine: number;
   sectionTitle?: string;
@@ -53,6 +54,7 @@ export interface Project {
   startLine: number;
   endLine: number;
   headings: Heading[];
+  slug?: string;
 }
 
 export interface Settings {


### PR DESCRIPTION
Introduces unique slugs for projects and sections to enable direct linking and navigation within the application. This change enhances user experience by allowing users to easily jump to specific project sections.

Updates the `Project` and `Task` types to include a `slug` property. Modifies the markdown parser to generate slugs for projects and sections based on their titles. Refactors `ProjectOverview` and `TimelineView` components to utilize slugs for navigation, improving routing and context display. Ensures compatibility with existing views by gracefully handling missing slugs. Addresses TypeScript errors in `EditableSection` by adding explicit types for `g` in flatMap operations.