### PR TITLE
refactor: Extract markdown parsing to utils

### DIFF
--- a/components/InteractiveTaskItem.tsx
+++ b/components/InteractiveTaskItem.tsx
@@ -5,21 +5,7 @@ import { Pencil, Save, X, CheckCircle2, CalendarDays, ChevronRight, Archive, Che
 import InputModal from './InputModal';
 import DatePickerModal from './DatePickerModal';
 import TaskReorderControls from './TaskReorderControls';
-
-// Re-usable parsing functions and components
-const parseInlineMarkdown = (text: string): React.ReactNode[] => {
-  const parts = text.split(/(\*\*.*?\*\*|\*.*?\*|\[.*?\]\(.*?\))/g);
-  return parts.map((part, index) => {
-    if (!part) return null;
-    if (part.startsWith('**') && part.endsWith('**')) return <strong key={index}>{part.slice(2, -2)}</strong>;
-    if (part.startsWith('*') && part.endsWith('*')) return <em key={index}>{part.slice(1, -1)}</em>;
-    const linkMatch = part.match(/\[(.*?)\]\((.*?)\)/);
-    if (linkMatch) return <a key={index} href={linkMatch[2]} target="_blank" rel="noopener noreferrer" className="text-indigo-400 hover:underline">{linkMatch[1]}</a>;
-    return part;
-  });
-};
-
-const InlineMarkdown: React.FC<{ text: string }> = ({ text }) => <>{parseInlineMarkdown(text)}</>;
+import { InlineMarkdown } from '../lib/markdownUtils';
 
 // InteractiveTaskItem Component
 interface InteractiveTaskItemProps {

--- a/components/ProjectOverview.tsx
+++ b/components/ProjectOverview.tsx
@@ -5,34 +5,7 @@ import { CheckCircle2, Circle, Users, Mail, DollarSign, ListChecks, BarChart2, C
 import ConfirmationModal from './ConfirmationModal';
 import { useProject } from '../contexts/ProjectContext';
 import TaskEditModal from './TaskEditModal';
-
-const formatMarkdownForEmail = (text: string): string => {
-  const linkRegex = /\[(.*?)\]\((.*?)\)/g;
-  return text.replace(linkRegex, (_match, linkText, url) => `${linkText} (${url})`);
-};
-
-const parseInlineMarkdown = (text: string): React.ReactNode[] => {
-  const parts = text.split(/(\*\*.*?\*\*|\*.*?\*|\[.*?\]\(.*?\))/g);
-  
-  return parts.map((part, index) => {
-    if (!part) return null;
-    if (part.startsWith('**') && part.endsWith('**')) {
-      return <strong key={index}>{part.slice(2, -2)}</strong>;
-    }
-    if (part.startsWith('*') && part.endsWith('*')) {
-      return <em key={index}>{part.slice(1, -1)}</em>;
-    }
-    const linkMatch = part.match(/\[(.*?)\]\((.*?)\)/);
-    if (linkMatch) {
-      return <a key={index} href={linkMatch[2]} target="_blank" rel="noopener noreferrer" className="text-indigo-400 hover:underline">{linkMatch[1]}</a>;
-    }
-    return part;
-  });
-};
-
-const InlineMarkdown: React.FC<{ text: string }> = ({ text }) => {
-    return <>{parseInlineMarkdown(text)}</>;
-};
+import { InlineMarkdown, formatMarkdownForEmail } from '../lib/markdownUtils';
 
 type ViewScope = 'single' | 'all';
 

--- a/components/TimelineView.tsx
+++ b/components/TimelineView.tsx
@@ -2,6 +2,7 @@ import React, { useMemo } from 'react';
 import type { User, Task } from '../types';
 import { CheckCircle2, Circle, AlertTriangle, Calendar, Clock, Inbox, ArrowRight } from 'lucide-react';
 import { useProject } from '../contexts/ProjectContext';
+import { InlineMarkdown } from '../lib/markdownUtils';
 
 type ViewScope = 'single' | 'all';
 
@@ -10,19 +11,6 @@ interface TimelineViewProps {
   viewScope: ViewScope;
   onNavigate: (projectTitle: string, sectionSlug: string) => void;
 }
-
-const parseInlineMarkdown = (text: string): React.ReactNode[] => {
-  const parts = text.split(/(\*\*.*?\*\*|\*.*?\*|\[.*?\]\(.*?\))/g);
-  return parts.map((part, index) => {
-    if (!part) return null;
-    if (part.startsWith('**') && part.endsWith('**')) return <strong key={index}>{part.slice(2, -2)}</strong>;
-    if (part.startsWith('*') && part.endsWith('*')) return <em key={index}>{part.slice(1, -1)}</em>;
-    const linkMatch = part.match(/\[(.*?)\]\((.*?)\)/);
-    if (linkMatch) return <a key={index} href={linkMatch[2]} target="_blank" rel="noopener noreferrer" className="text-indigo-400 hover:underline">{linkMatch[1]}</a>;
-    return part;
-  });
-};
-const InlineMarkdown: React.FC<{ text: string }> = ({ text }) => <>{parseInlineMarkdown(text)}</>;
 
 const TimelineTaskItem: React.FC<{ task: Task; user: User | null; viewScope: ViewScope; onNavigate: (projectTitle: string, sectionSlug: string) => void; }> = ({ task, user, viewScope, onNavigate }) => {
   return (

--- a/lib/markdownUtils.ts
+++ b/lib/markdownUtils.ts
@@ -1,0 +1,58 @@
+import React from 'react';
+
+/**
+ * Parses a string with inline markdown (bold, italic, links) into an array of React nodes.
+ * @param text The string to parse.
+ * @returns An array of React nodes.
+ */
+export const parseInlineMarkdown = (text: string): React.ReactNode[] => {
+  if (!text) return [];
+  // Regex to split by bold, italic, or link, keeping the delimiters
+  const parts = text.split(/(\*\*.*?\*\*|\*.*?\*|\[.*?\]\(.*?\))/g);
+  
+  return parts.map((part, index) => {
+    if (!part) return null;
+
+    // Bold: **text**
+    if (part.startsWith('**') && part.endsWith('**')) {
+      // FIX: Use React.createElement to avoid JSX syntax errors in .ts file.
+      return React.createElement('strong', { key: index }, part.slice(2, -2));
+    }
+
+    // Italic: *text*
+    if (part.startsWith('*') && part.endsWith('*')) {
+      // FIX: Use React.createElement to avoid JSX syntax errors in .ts file.
+      return React.createElement('em', { key: index }, part.slice(1, -1));
+    }
+
+    // Link: [text](url)
+    const linkMatch = part.match(/\[(.*?)\]\((.*?)\)/);
+    if (linkMatch) {
+      // FIX: Use React.createElement to avoid JSX syntax errors in .ts file.
+      return React.createElement('a', { key: index, href: linkMatch[2], target: "_blank", rel: "noopener noreferrer", className: "text-indigo-400 hover:underline" }, linkMatch[1]);
+    }
+
+    // Plain text
+    return part;
+  });
+};
+
+/**
+ * A React component that renders a string with inline markdown.
+ */
+export const InlineMarkdown: React.FC<{ text: string }> = ({ text }) => {
+    // FIX: Use React.createElement to avoid JSX syntax errors in .ts file.
+    return React.createElement(React.Fragment, null, ...parseInlineMarkdown(text));
+};
+
+/**
+ * Converts markdown syntax (specifically links) to a plain text format suitable for email clients.
+ * @param text The markdown string to format.
+ * @returns A plain text string.
+ */
+export const formatMarkdownForEmail = (text: string): string => {
+  if (!text) return '';
+  const linkRegex = /\[(.*?)\]\((.*?)\)/g;
+  // Replaces [link text](url) with "link text (url)"
+  return text.replace(linkRegex, (_match, linkText, url) => `${linkText} (${url})`);
+};


### PR DESCRIPTION
Moves markdown parsing logic and the InlineMarkdown component to a new `markdownUtils` module. This centralizes reusable functionality and cleans up components that were previously duplicating this logic.

Also includes minor regex adjustments for assignee, date, and cost parsing to handle optional backslashes.