### PR TITLE
feat: Add task pinning functionality

### DIFF
--- a/components/EditableDocumentView.tsx
+++ b/components/EditableDocumentView.tsx
@@ -16,11 +16,12 @@ interface EditableDocumentViewProps {
   currentProjectIndex: number;
   isArchiveView?: boolean;
   hideCompletedTasks?: boolean;
+  showPinnedOnly?: boolean;
 }
 
 const EditableDocumentView: React.FC<EditableDocumentViewProps> = (props) => {
-  const { markdown, projects, viewScope, currentProjectIndex, isArchiveView, hideCompletedTasks } = props;
-  const { users, updateSection, moveSection, duplicateSection, toggleTask, updateTaskBlock, archiveSection, restoreSection, archiveTasks, reorderTask, archiveMarkdown, clearArchive } = useProject();
+  const { markdown, projects, viewScope, currentProjectIndex, isArchiveView, hideCompletedTasks, showPinnedOnly } = props;
+  const { users, updateSection, moveSection, duplicateSection, toggleTask, toggleTaskPin, updateTaskBlock, archiveSection, restoreSection, archiveTasks, reorderTask, archiveMarkdown, clearArchive } = useProject();
   const sections = useSectionParser(markdown);
   const [collapsedSections, setCollapsedSections] = useState<Set<number>>(new Set());
   const [isClearConfirmOpen, setIsClearConfirmOpen] = useState(false);
@@ -136,6 +137,10 @@ const EditableDocumentView: React.FC<EditableDocumentViewProps> = (props) => {
     // lineIndex received from InteractiveTaskItem is already absolute
     toggleTask(lineIndex, isCompleted);
   }, [toggleTask]);
+  
+  const handleToggleTaskPin = useCallback((lineIndex: number) => {
+    toggleTaskPin(lineIndex);
+  }, [toggleTaskPin]);
 
   const handleUpdateTaskBlock = useCallback((startLine: number, lineCount: number, newContent: string) => {
     // startLine received from InteractiveTaskItem is already an absolute line index
@@ -217,6 +222,7 @@ const EditableDocumentView: React.FC<EditableDocumentViewProps> = (props) => {
                                 onMoveSection={handleMoveSectionWithOffset}
                                 onDuplicateSection={handleDuplicateSectionWithOffset}
                                 onToggle={handleToggleTask}
+                                onTogglePin={handleToggleTaskPin}
                                 onUpdateTaskBlock={handleUpdateTaskBlock}
                                 onArchiveSection={handleArchiveSection}
                                 onRestoreSection={handleRestoreSection}
@@ -229,6 +235,7 @@ const EditableDocumentView: React.FC<EditableDocumentViewProps> = (props) => {
                                 projectStartLine={projectStartLine}
                                 isArchiveView={isArchiveView}
                                 hideCompletedTasks={hideCompletedTasks}
+                                showPinnedOnly={showPinnedOnly}
                                 isCollapsed={collapsedSections.has(section.startLine)}
                                 onToggleCollapse={() => handleToggleCollapse(section.startLine)}
                             />

--- a/components/InteractiveTaskItem.tsx
+++ b/components/InteractiveTaskItem.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useCallback, useRef, useEffect, useMemo } from 'react';
 import type { User, TaskUpdate, Task, Heading, Project } from '../types';
 import Toolbar from './Toolbar';
-import { Pencil, Save, X, CheckCircle2, CalendarDays, ChevronRight, Archive, ChevronsUp, ChevronUp, ChevronDown, ChevronsDown } from 'lucide-react';
+import { Pencil, Save, X, CheckCircle2, CalendarDays, ChevronRight, Archive, Pin } from 'lucide-react';
 import InputModal from './InputModal';
 import DatePickerModal from './DatePickerModal';
 import TaskReorderControls from './TaskReorderControls';
@@ -12,6 +12,7 @@ interface InteractiveTaskItemProps {
     task: Task;
     taskBlockContent: string;
     onToggle: (absoluteLineIndex: number, isCompleted: boolean) => void;
+    onTogglePin: (absoluteLineIndex: number) => void;
     onUpdateTaskBlock: (absoluteStartLine: number, originalLineCount: number, newContent: string) => void;
     users: User[];
     isArchiveView?: boolean;
@@ -21,7 +22,7 @@ interface InteractiveTaskItemProps {
     totalTasksInList: number;
 }
 
-const InteractiveTaskItem: React.FC<InteractiveTaskItemProps> = ({ task, taskBlockContent, onToggle, onUpdateTaskBlock, users, isArchiveView, onArchiveTask, onReorderTask, taskIndexInList, totalTasksInList }) => {
+const InteractiveTaskItem: React.FC<InteractiveTaskItemProps> = ({ task, taskBlockContent, onToggle, onTogglePin, onUpdateTaskBlock, users, isArchiveView, onArchiveTask, onReorderTask, taskIndexInList, totalTasksInList }) => {
   const [isEditing, setIsEditing] = useState(false);
   const [editedContent, setEditedContent] = useState(taskBlockContent);
   const [areUpdatesVisible, setAreUpdatesVisible] = useState(false);
@@ -377,6 +378,15 @@ const InteractiveTaskItem: React.FC<InteractiveTaskItemProps> = ({ task, taskBlo
                         canMoveUp={taskIndexInList > 0}
                         canMoveDown={taskIndexInList < totalTasksInList - 1}
                     />
+                )}
+                {!isArchiveView && (
+                    <button 
+                        onClick={() => onTogglePin(task.lineIndex)} 
+                        className={`p-2 rounded-full hover:bg-slate-700 ${task.pinned ? 'text-yellow-400' : 'text-slate-400'}`}
+                        title={task.pinned ? "Unpin task" : "Pin task"}
+                    >
+                        <Pin className={`w-4 h-4 ${task.pinned ? 'fill-current' : ''}`} />
+                    </button>
                 )}
                 {!isArchiveView && task.completed && (
                     <button 

--- a/components/ProjectOverview.tsx
+++ b/components/ProjectOverview.tsx
@@ -1,7 +1,7 @@
 
 import React, { useState, useMemo, useCallback } from 'react';
 import type { User, Task, GroupedTasks, Settings } from '../types';
-import { CheckCircle2, Circle, Users, Mail, DollarSign, ListChecks, BarChart2, CalendarDays, Pencil } from 'lucide-react';
+import { CheckCircle2, Circle, Users, Mail, DollarSign, ListChecks, BarChart2, CalendarDays, Pencil, Pin } from 'lucide-react';
 import ConfirmationModal from './ConfirmationModal';
 import { useProject } from '../contexts/ProjectContext';
 import TaskEditModal from './TaskEditModal';
@@ -22,8 +22,9 @@ const TaskItem: React.FC<{
     task: Task; 
     viewScope: ViewScope; 
     onEdit: (task: Task) => void;
+    onTogglePin: (lineIndex: number) => void;
     onNavigate: (projectTitle: string, sectionSlug: string) => void;
-}> = ({ task, viewScope, onEdit, onNavigate }) => {
+}> = ({ task, viewScope, onEdit, onTogglePin, onNavigate }) => {
     const getDueDateInfo = (dateString: string | null, isCompleted: boolean): { color: string, label: string } | null => {
         if (!dateString || isCompleted) return null;
         const today = new Date();
@@ -114,7 +115,15 @@ const TaskItem: React.FC<{
             </span>
           )}
         </div>
-        <div className="absolute top-0 right-0">
+        <div className="absolute top-0 right-0 flex items-center">
+            <button
+                onClick={() => onTogglePin(task.lineIndex)}
+                className={`p-1 rounded-full hover:bg-slate-700 ${task.pinned ? 'text-yellow-400' : 'text-slate-400'} opacity-0 group-hover:opacity-100 transition-opacity focus:opacity-100`}
+                aria-label={task.pinned ? "Unpin task" : "Pin task"}
+                title={task.pinned ? "Unpin task" : "Pin task"}
+            >
+                <Pin className={`w-4 h-4 ${task.pinned ? 'fill-current' : ''}`} />
+            </button>
             <button
                 onClick={() => onEdit(task)}
                 className="p-1 rounded-full hover:bg-slate-700 text-slate-400 opacity-0 group-hover:opacity-100 transition-opacity focus:opacity-100"
@@ -148,7 +157,7 @@ const UserTaskCard: React.FC<{
     onEditTask: (task: Task) => void;
     onNavigate: (projectTitle: string, sectionSlug: string) => void;
 }> = ({ user, tasks, projectTitle, viewScope, onEditTask, onNavigate }) => {
-  const { users, settings, addBulkTaskUpdates } = useProject();
+  const { users, settings, addBulkTaskUpdates, toggleTaskPin } = useProject();
   const [isConfirmationOpen, setIsConfirmationOpen] = useState(false);
   const completedTasks = tasks.filter(t => t.completed).length;
   const totalTasks = tasks.length;
@@ -242,7 +251,7 @@ const UserTaskCard: React.FC<{
         </div>
         <div className="space-y-3 overflow-y-auto flex-grow">
           {tasks.map((task, index) => (
-            <TaskItem key={index} task={task} viewScope={viewScope} onEdit={onEditTask} onNavigate={onNavigate}/>
+            <TaskItem key={index} task={task} viewScope={viewScope} onEdit={onEditTask} onTogglePin={toggleTaskPin} onNavigate={onNavigate}/>
           ))}
         </div>
       </div>
@@ -281,6 +290,7 @@ const StatCard: React.FC<{ icon: React.ReactNode; title: string; value: string; 
 
 const ProjectOverview: React.FC<ProjectOverviewProps> = ({ groupedTasks, unassignedTasks, projectTitle, viewScope, totalCost, onNavigate }) => {
   const [editingTask, setEditingTask] = useState<Task | null>(null);
+  const { toggleTaskPin } = useProject();
 
   const handleEditTask = useCallback((task: Task) => {
     setEditingTask(task);
@@ -326,7 +336,7 @@ const ProjectOverview: React.FC<ProjectOverviewProps> = ({ groupedTasks, unassig
             </div>
             <div className="space-y-3">
               {unassignedTasks.map((task, index) => (
-                <TaskItem key={index} task={task} viewScope={viewScope} onEdit={handleEditTask} onNavigate={onNavigate} />
+                <TaskItem key={index} task={task} viewScope={viewScope} onEdit={handleEditTask} onTogglePin={toggleTaskPin} onNavigate={onNavigate} />
               ))}
             </div>
           </div>

--- a/components/TimelineView.tsx
+++ b/components/TimelineView.tsx
@@ -1,6 +1,7 @@
+
 import React, { useMemo } from 'react';
 import type { User, Task } from '../types';
-import { CheckCircle2, Circle, AlertTriangle, Calendar, Clock, Inbox, ArrowRight } from 'lucide-react';
+import { CheckCircle2, Circle, AlertTriangle, Calendar, Clock, Inbox, ArrowRight, Pin } from 'lucide-react';
 import { useProject } from '../contexts/ProjectContext';
 import { InlineMarkdown } from '../lib/markdownUtils';
 
@@ -12,9 +13,9 @@ interface TimelineViewProps {
   onNavigate: (projectTitle: string, sectionSlug: string) => void;
 }
 
-const TimelineTaskItem: React.FC<{ task: Task; user: User | null; viewScope: ViewScope; onNavigate: (projectTitle: string, sectionSlug: string) => void; }> = ({ task, user, viewScope, onNavigate }) => {
+const TimelineTaskItem: React.FC<{ task: Task; user: User | null; viewScope: ViewScope; onNavigate: (projectTitle: string, sectionSlug: string) => void; onTogglePin: (lineIndex: number) => void; }> = ({ task, user, viewScope, onNavigate, onTogglePin }) => {
   return (
-    <div className="flex items-start space-x-3 p-3 bg-slate-800/50 rounded-md">
+    <div className="flex items-start space-x-3 p-3 bg-slate-800/50 rounded-md group">
       {task.completed ? (
         <CheckCircle2 className="h-5 w-5 text-green-500 flex-shrink-0 mt-0.5" />
       ) : (
@@ -69,13 +70,25 @@ const TimelineTaskItem: React.FC<{ task: Task; user: User | null; viewScope: Vie
             return null;
         })()}
       </div>
-      <span className="text-xs font-mono whitespace-nowrap text-slate-400">{task.dueDate}</span>
+      <div className="flex items-center space-x-2">
+        <span className="text-xs font-mono whitespace-nowrap text-slate-400">{task.dueDate}</span>
+        <div className="opacity-0 group-hover:opacity-100 transition-opacity">
+            <button
+                onClick={() => onTogglePin(task.lineIndex)}
+                className={`p-1 rounded-full hover:bg-slate-700 ${task.pinned ? 'text-yellow-400' : 'text-slate-400'}`}
+                aria-label={task.pinned ? "Unpin task" : "Pin task"}
+                title={task.pinned ? "Unpin task" : "Pin task"}
+            >
+                <Pin className={`w-4 h-4 ${task.pinned ? 'fill-current' : ''}`} />
+            </button>
+        </div>
+      </div>
     </div>
   );
 };
 
 const TimelineSection: React.FC<{ title: string; icon: React.ReactNode; tasks: Task[]; viewScope: ViewScope; onNavigate: (projectTitle: string, sectionSlug: string) => void; }> = ({ title, icon, tasks, viewScope, onNavigate }) => {
-    const { users } = useProject();
+    const { users, toggleTaskPin } = useProject();
     const userByAlias = useMemo(() => new Map(users.map(u => [u.alias, u])), [users]);
     if (tasks.length === 0) return null;
     return (
@@ -93,6 +106,7 @@ const TimelineSection: React.FC<{ title: string; icon: React.ReactNode; tasks: T
                         user={task.assigneeAlias ? userByAlias.get(task.assigneeAlias) ?? null : null}
                         viewScope={viewScope}
                         onNavigate={onNavigate}
+                        onTogglePin={toggleTaskPin}
                     />
                 ))}
             </div>

--- a/contexts/ProjectContext.tsx
+++ b/contexts/ProjectContext.tsx
@@ -18,7 +18,7 @@ Use H1 headings (e.g., '# My Project') to create separate projects within this f
 
 ## Phase 1: Design
 
-- [ ] Wireframing and user flows !2024-08-10 (@alice) ($1500)
+- [ ] Wireframing and user flows !2024-08-10 (@alice) ($1500) 📌
   - 2024-07-26: Initial sketches completed. (@alice)
   - 2024-07-27: Discussed with the product team, got feedback.
 - [x] UI/UX Design system (@alice) ~2024-07-20 ($2500)
@@ -26,7 +26,7 @@ Use H1 headings (e.g., '# My Project') to create separate projects within this f
 
 ## Phase 2: Development
 
-- [ ] Setup CI/CD pipeline !2024-09-01 (@bob) ($2000)
+- [ ] Setup CI/CD pipeline !2024-09-01 (@bob) ($2000) 📌
 - [ ] Develop core API endpoints !2024-08-25 (@charlie) ($4000)
 - [ ] Frontend component library (@diana) ($3500)
 - [ ] Implement user authentication ($1200)
@@ -90,6 +90,7 @@ interface ProjectContextType {
     archiveProjects: Project[];
     updateSection: (startLine: number, endLine: number, newContent: string, isArchive: boolean) => void;
     toggleTask: (absoluteLineIndex: number, isCompleted: boolean) => void;
+    toggleTaskPin: (absoluteLineIndex: number) => void;
     updateTaskBlock: (absoluteStartLine: number, originalLineCount: number, newContent: string, isArchive: boolean) => void;
     moveSection: (sectionToMove: { startLine: number, endLine: number }, destinationLine: number) => void;
     duplicateSection: (sectionToDuplicate: { startLine: number, endLine: number }, destinationLine: number) => void;
@@ -260,6 +261,24 @@ export const ProjectProvider: React.FC<{ children: React.ReactNode }> = ({ child
             });
         });
     }, [performAstUpdate]);
+    
+    const toggleTaskPin = useCallback((absoluteLineIndex: number) => {
+        setMarkdown(prev => {
+            const lines = prev.split('\n');
+            if (absoluteLineIndex >= lines.length) return prev;
+            let line = lines[absoluteLineIndex];
+
+            const pinRegex = /\s*📌\s*$/;
+            if (pinRegex.test(line)) {
+                line = line.replace(pinRegex, '');
+            } else {
+                line = line.trimEnd() + ' 📌';
+            }
+
+            lines[absoluteLineIndex] = line;
+            return lines.join('\n');
+        });
+    }, []);
 
     const moveOrDuplicateSection = useCallback((
         sectionLines: { startLine: number; endLine: number },
@@ -604,7 +623,7 @@ export const ProjectProvider: React.FC<{ children: React.ReactNode }> = ({ child
 
     const value: ProjectContextType = {
         markdown, setMarkdown, archiveMarkdown, users, setUsers, settings, saveSettings,
-        projects, archiveProjects, updateSection, toggleTask, updateTaskBlock, moveSection,
+        projects, archiveProjects, updateSection, toggleTask, toggleTaskPin, updateTaskBlock, moveSection,
         duplicateSection, addBulkTaskUpdates, addUser, updateUser, deleteUser,
         importProject, handleRequestLocalRestore, archiveSection, restoreSection,
         archiveTasks, reorderTask, clearArchive

--- a/hooks/useMarkdownParser.ts
+++ b/hooks/useMarkdownParser.ts
@@ -1,4 +1,3 @@
-
 import { useMemo } from 'react';
 import { User, Task, GroupedTasks, TaskUpdate, Project, Heading } from '../types';
 import { remark } from 'remark';
@@ -122,6 +121,13 @@ export const useMarkdownParser = (markdown: string, users: User[]): Project[] =>
                 if (!paragraphNode) return;
 
                 let fullTaskText = stringifier.stringify({ type: 'paragraph', children: paragraphNode.children }).trim();
+                
+                const pinRegex = /\s*📌\s*$/;
+                const pinned = pinRegex.test(fullTaskText);
+                if (pinned) {
+                    fullTaskText = fullTaskText.replace(pinRegex, '');
+                }
+
                 let assigneeAlias: string | null = null;
                 let completionDate: string | null = null;
                 let creationDate: string | null = null;
@@ -190,6 +196,7 @@ export const useMarkdownParser = (markdown: string, users: User[]): Project[] =>
                     lineIndex: node.position.start.line - 1,
                     text: fullTaskText,
                     completed: node.checked,
+                    pinned,
                     assigneeAlias,
                     creationDate,
                     completionDate,

--- a/types.ts
+++ b/types.ts
@@ -18,6 +18,7 @@ export interface Task {
   lineIndex: number;
   text: string;
   completed: boolean;
+  pinned: boolean;
   assigneeAlias: string | null;
   creationDate?: string | null;
   completionDate: string | null;


### PR DESCRIPTION
Introduces the ability to pin important tasks, making them easier to find and manage.

- Adds a `pinned` boolean field to the `Task` interface.
- Enables pinning tasks by appending the "📌" emoji to the task text.
- Introduces a "Show Pinned Only" toggle in the UI to filter tasks.
- Updates the parser to correctly identify and extract pinned tasks.
- Integrates pin toggling into the `ProjectOverview` and `EditableDocumentView` components.